### PR TITLE
Add CODEOWNERS for .github/ protection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Require admin approval for security-critical files
+/.github/ @shineli1984


### PR DESCRIPTION
Requires @shineli1984 approval for any changes to .github/ — prevents agents from gaming the security scan by modifying it in the same PR.