### PR TITLE
Fix frame-rate dependent movement with delta-time

### DIFF
--- a/game/index.html
+++ b/game/index.html
@@ -63,19 +63,20 @@
     });
 
     // --- Update ---
-    function update() {
-      // Movement
+    function update(dt) {
+      // Movement (speed normalized to 60fps feel)
+      const px = player.speed * 60 * dt;
       if (keys['ArrowLeft'] || keys['a'] || keys['A']) {
-        player.x -= player.speed;
+        player.x -= px;
       }
       if (keys['ArrowRight'] || keys['d'] || keys['D']) {
-        player.x += player.speed;
+        player.x += px;
       }
       if (keys['ArrowUp'] || keys['w'] || keys['W']) {
-        player.y -= player.speed;
+        player.y -= px;
       }
       if (keys['ArrowDown'] || keys['s'] || keys['S']) {
-        player.y += player.speed;
+        player.y += px;
       }
 
       // Boundary collision
@@ -100,13 +101,17 @@
     }
 
     // --- Game Loop ---
-    function gameLoop() {
-      update();
+    let lastTime = performance.now();
+
+    function gameLoop(now) {
+      const dt = (now - lastTime) / 1000; // seconds since last frame
+      lastTime = now;
+      update(dt);
       render();
       requestAnimationFrame(gameLoop);
     }
 
-    gameLoop();
+    requestAnimationFrame(gameLoop);
   </script>
 </body>
 </html>


### PR DESCRIPTION
Fixes #9.

Uses `performance.now()` delta-time to decouple movement from frame rate. Speed is normalized to `speed * 60 * dt` so the game feels identical on 60Hz, 144Hz, or throttled tabs.

**Changes:**
- `update()` now takes a `dt` parameter (seconds since last frame)
- Game loop tracks `lastTime` and passes delta to update
- Movement: `player.speed * 60 * dt` pixels per frame (same feel as the old 4px/frame at 60fps)

No visual or behavioral change at 60fps — just consistent behavior everywhere else.