### PR TITLE
Gameplay: soft starvation — energy depletion and nutrient feeding

### DIFF
--- a/game/index.html
+++ b/game/index.html
@@ -48,6 +48,30 @@
       z-index: 10;
       pointer-events: none;
     }
+    #energy-bar {
+      position: absolute;
+      top: 62px;
+      left: 20px;
+      font-size: 12px;
+      color: rgba(184, 233, 134, 0.5);
+      z-index: 10;
+      pointer-events: none;
+    }
+    #energy-bar .bar-bg {
+      display: inline-block;
+      width: 120px;
+      height: 8px;
+      background: rgba(184, 233, 134, 0.1);
+      border-radius: 4px;
+      vertical-align: middle;
+      margin-left: 6px;
+      overflow: hidden;
+    }
+    #energy-bar .bar-fill {
+      height: 100%;
+      border-radius: 4px;
+      transition: width 0.15s ease-out, background 0.3s ease;
+    }
     .controls {
       position: absolute;
       bottom: 16px;
@@ -112,6 +136,7 @@
     </div>
     <div id="score">Absorbed: 0</div>
     <div id="branch-hint">Tendril 1/1 &nbsp;[Space to fork, Tab to switch]</div>
+    <div id="energy-bar">Energy <span class="bar-bg"><span class="bar-fill" style="width:100%; background:#b8e986;"></span></span></div>
     <canvas id="game" width="960" height="640"></canvas>
     <div class="controls">Reach &mdash; arrow keys / WASD &nbsp;&middot;&nbsp; Fork &mdash; space / click &nbsp;&middot;&nbsp; Switch tendril &mdash; tab</div>
   </div>
@@ -164,9 +189,17 @@
     network.nodes.push({ x: originX, y: originY, radius: 6 });
 
     // --- Branching system (issue #23) ---
+    // --- Soft starvation (issue #40): energy system ---
+    const ENERGY_MAX = 1.0;
+    const ENERGY_DRAIN_IDLE = 0.015;    // energy lost per second while idle (slow background drain)
+    const ENERGY_DRAIN_GROWING = 0.08;  // energy lost per second while actively growing
+    const ENERGY_REPLENISH = 0.4;       // energy gained per nutrient collected by this branch
+    const ENERGY_STARVED_THRESHOLD = 0; // at 0 energy, branch stops growing
+
     const branches = [{
       tipIndex: 0,
-      growing: { x: originX, y: originY, dist: 0 }
+      growing: { x: originX, y: originY, dist: 0 },
+      energy: ENERGY_MAX
     }];
     let activeBranch = 0;
 
@@ -241,6 +274,8 @@
     let score = 0;
     const scoreEl = document.getElementById('score');
     const branchHintEl = document.getElementById('branch-hint');
+    const energyBarEl = document.getElementById('energy-bar');
+    const energyFillEl = energyBarEl.querySelector('.bar-fill');
 
     function spawnNutrient(nearOrigin) {
       let x, y;
@@ -274,6 +309,8 @@
       const now = performance.now();
       const current = branches[activeBranch];
       if (current.growing.dist < BRANCH_MIN_DIST || (now - lastBranchTime) < BRANCH_COOLDOWN) return;
+      // Issue #40: starved branches cannot fork
+      if (current.energy <= ENERGY_STARVED_THRESHOLD) return;
       lastBranchTime = now;
       if (current.growing.dist > 5) {
         const newNode = { x: current.growing.x, y: current.growing.y, radius: NODE_RADIUS };
@@ -285,9 +322,12 @@
       }
       const forkTip = current.tipIndex;
       const forkNode = network.nodes[forkTip];
+      // Issue #40: forking costs energy from the parent branch
+      current.energy = Math.max(0, current.energy - 0.15);
       branches.push({
         tipIndex: forkTip,
-        growing: { x: forkNode.x, y: forkNode.y, dist: 0 }
+        growing: { x: forkNode.x, y: forkNode.y, dist: 0 },
+        energy: ENERGY_MAX * 0.6 // new branches start at 60% — must be fed soon
       });
       activeBranch = branches.length - 1;
       spawnBurst(forkNode.x, forkNode.y, PALETTE.myceliumGlow);
@@ -295,7 +335,20 @@
     }
 
     function updateBranchHint() {
-      branchHintEl.textContent = 'Tendril ' + (activeBranch + 1) + '/' + branches.length + '  [Space to fork, Tab to switch]';
+      const e = branches[activeBranch].energy;
+      const pct = Math.round(e * 100);
+      const starved = e <= ENERGY_STARVED_THRESHOLD;
+      branchHintEl.textContent = 'Tendril ' + (activeBranch + 1) + '/' + branches.length +
+        (starved ? '  STARVED' : '') + '  [Space to fork, Tab to switch]';
+      // Update energy bar
+      energyFillEl.style.width = pct + '%';
+      if (e > 0.5) {
+        energyFillEl.style.background = PALETTE.myceliumGlow;
+      } else if (e > 0.2) {
+        energyFillEl.style.background = PALETTE.sporeGold;
+      } else {
+        energyFillEl.style.background = PALETTE.decayViolet;
+      }
     }
 
     // --- Input ---
@@ -324,6 +377,30 @@
       return Math.sqrt(dx * dx + dy * dy);
     }
 
+    // Issue #40: find the nearest branch to a point (for nutrient collection)
+    function nearestBranch(px, py) {
+      let best = 0;
+      let bestDist = Infinity;
+      for (let i = 0; i < branches.length; i++) {
+        const d = dist(px, py, branches[i].growing.x, branches[i].growing.y);
+        if (d < bestDist) {
+          bestDist = d;
+          best = i;
+        }
+      }
+      return best;
+    }
+
+    // Issue #40: interpolate between two hex colors
+    function lerpColor(a, b, t) {
+      const ar = parseInt(a.slice(1,3), 16), ag = parseInt(a.slice(3,5), 16), ab = parseInt(a.slice(5,7), 16);
+      const br_ = parseInt(b.slice(1,3), 16), bg = parseInt(b.slice(3,5), 16), bb = parseInt(b.slice(5,7), 16);
+      const r = Math.round(ar + (br_ - ar) * t);
+      const g = Math.round(ag + (bg - ag) * t);
+      const bl = Math.round(ab + (bb - ab) * t);
+      return 'rgb(' + r + ',' + g + ',' + bl + ')';
+    }
+
     // --- Update ---
     function update(dt) {
       if (!gameStarted) return; // Pause game until title dismissed
@@ -335,59 +412,78 @@
       // Issue #24: speed scales with score
       growSpeed = BASE_GROW_SPEED + score * 8;
 
+      // --- Issue #40: drain energy from ALL branches ---
+      for (const b of branches) {
+        b.energy = Math.max(0, b.energy - ENERGY_DRAIN_IDLE * dt);
+      }
+
       let dx = 0, dy = 0;
       if (keys['ArrowLeft'] || keys['a'] || keys['A']) dx -= 1;
       if (keys['ArrowRight'] || keys['d'] || keys['D']) dx += 1;
       if (keys['ArrowUp'] || keys['w'] || keys['W']) dy -= 1;
       if (keys['ArrowDown'] || keys['s'] || keys['S']) dy += 1;
 
+      // Issue #40: starved branches cannot grow
+      const isStarved = branch.energy <= ENERGY_STARVED_THRESHOLD;
+
       if (dx !== 0 || dy !== 0) {
-        const len = Math.sqrt(dx * dx + dy * dy);
-        dx /= len; dy /= len;
-        const step = growSpeed * dt;
-        growing.x += dx * step;
-        growing.y += dy * step;
+        if (!isStarved) {
+          // Active growth drains extra energy
+          branch.energy = Math.max(0, branch.energy - ENERGY_DRAIN_GROWING * dt);
 
-        // Issue #31: bounce off canvas edges instead of getting stuck
-        if (growing.x < EDGE_MARGIN) {
-          growing.x = EDGE_MARGIN + (EDGE_MARGIN - growing.x);
-        } else if (growing.x > W - EDGE_MARGIN) {
-          growing.x = (W - EDGE_MARGIN) - (growing.x - (W - EDGE_MARGIN));
-        }
-        if (growing.y < EDGE_MARGIN) {
-          growing.y = EDGE_MARGIN + (EDGE_MARGIN - growing.y);
-        } else if (growing.y > H - EDGE_MARGIN) {
-          growing.y = (H - EDGE_MARGIN) - (growing.y - (H - EDGE_MARGIN));
-        }
-        // Safety clamp in case bounce overshoots
-        growing.x = Math.max(EDGE_MARGIN, Math.min(W - EDGE_MARGIN, growing.x));
-        growing.y = Math.max(EDGE_MARGIN, Math.min(H - EDGE_MARGIN, growing.y));
+          const len = Math.sqrt(dx * dx + dy * dy);
+          dx /= len; dy /= len;
+          const step = growSpeed * dt;
+          growing.x += dx * step;
+          growing.y += dy * step;
 
-        growing.dist += step;
-        if (growing.dist >= TENDRIL_MAX_LEN) {
-          const newNode = { x: growing.x, y: growing.y, radius: NODE_RADIUS };
-          network.nodes.push(newNode);
-          const newIndex = network.nodes.length - 1;
-          network.segments.push({ from: tipIndex, to: newIndex });
-          tipIndex = newIndex;
-          branch.tipIndex = newIndex;
-          growing.dist = 0;
+          // Issue #31: bounce off canvas edges instead of getting stuck
+          if (growing.x < EDGE_MARGIN) {
+            growing.x = EDGE_MARGIN + (EDGE_MARGIN - growing.x);
+          } else if (growing.x > W - EDGE_MARGIN) {
+            growing.x = (W - EDGE_MARGIN) - (growing.x - (W - EDGE_MARGIN));
+          }
+          if (growing.y < EDGE_MARGIN) {
+            growing.y = EDGE_MARGIN + (EDGE_MARGIN - growing.y);
+          } else if (growing.y > H - EDGE_MARGIN) {
+            growing.y = (H - EDGE_MARGIN) - (growing.y - (H - EDGE_MARGIN));
+          }
+          // Safety clamp in case bounce overshoots
+          growing.x = Math.max(EDGE_MARGIN, Math.min(W - EDGE_MARGIN, growing.x));
+          growing.y = Math.max(EDGE_MARGIN, Math.min(H - EDGE_MARGIN, growing.y));
+
+          growing.dist += step;
+          if (growing.dist >= TENDRIL_MAX_LEN) {
+            const newNode = { x: growing.x, y: growing.y, radius: NODE_RADIUS };
+            network.nodes.push(newNode);
+            const newIndex = network.nodes.length - 1;
+            network.segments.push({ from: tipIndex, to: newIndex });
+            tipIndex = newIndex;
+            branch.tipIndex = newIndex;
+            growing.dist = 0;
+          }
         }
       }
+
+      // Update HUD energy bar each frame
+      updateBranchHint();
 
       updateParticles(dt);
 
       // --- Magnetic nutrient pull (v0.2: chemical gradients) ---
-      // Nutrients drift toward the nearest branch tip within range.
-      // Quadratic inverse-distance: gentle far away, strong up close.
+      // Issue #40: starved branches don't exert magnetic pull
       for (const n of nutrients) {
         let closestDist = Infinity;
         let pullDx = 0, pullDy = 0;
 
         // Check all branch tips (growing points)
         for (const b of branches) {
+          // Starved branches lose their magnetic pull
+          if (b.energy <= ENERGY_STARVED_THRESHOLD) continue;
           const d = dist(n.x, n.y, b.growing.x, b.growing.y);
-          if (d < MAGNETIC_RADIUS && d < closestDist && d > 1) {
+          // Scale magnetic range by energy — low energy = shorter reach
+          const effectiveRadius = MAGNETIC_RADIUS * Math.max(0.3, b.energy);
+          if (d < effectiveRadius && d < closestDist && d > 1) {
             closestDist = d;
             pullDx = (b.growing.x - n.x) / d;
             pullDy = (b.growing.y - n.y) / d;
@@ -416,27 +512,28 @@
       }
 
       // Issue #22: generous collection radius
+      // Issue #40: collection replenishes the nearest branch's energy
       for (let i = nutrients.length - 1; i >= 0; i--) {
         const n = nutrients[i];
         if (dist(growing.x, growing.y, n.x, n.y) < COLLECT_RADIUS) {
-          collectNutrient(i); continue;
+          collectNutrient(i, n.x, n.y); continue;
         }
         let collected = false;
         for (const b of branches) {
           if (dist(b.growing.x, b.growing.y, n.x, n.y) < COLLECT_RADIUS) {
-            collectNutrient(i); collected = true; break;
+            collectNutrient(i, n.x, n.y); collected = true; break;
           }
         }
         if (collected) continue;
         for (const node of network.nodes) {
           if (dist(node.x, node.y, n.x, n.y) < n.radius + node.radius + 15) {
-            collectNutrient(i); break;
+            collectNutrient(i, node.x, node.y); break;
           }
         }
       }
     }
 
-    function collectNutrient(index) {
+    function collectNutrient(index, nx, ny) {
       const collected = nutrients[index];
       spawnBurst(collected.x, collected.y, PALETTE.sporeGold);
       nutrients.splice(index, 1);
@@ -444,6 +541,12 @@
       scoreEl.textContent = 'Absorbed: ' + score;
       spawnNutrient(false);
       if (Math.random() < 0.3) spawnNutrient(false);
+
+      // Issue #40: replenish energy for the nearest branch
+      const bi = nearestBranch(nx, ny);
+      const fed = branches[bi];
+      fed.energy = Math.min(ENERGY_MAX, fed.energy + ENERGY_REPLENISH);
+
       scoreEl.style.color = '#fff';
       scoreEl.style.textShadow = '0 0 20px rgba(244, 211, 94, 0.8)';
       setTimeout(function() {
@@ -480,10 +583,10 @@
 
       // Network segments — glow intensifies with score
       ctx.save();
-      ctx.strokeStyle = 'rgba(184, 233, 134, ' + (0.4 + glowBoost * 0.3) + ')';
       ctx.shadowBlur = 6 + glowBoost * 12;
       ctx.shadowColor = PALETTE.myceliumGlow;
       ctx.lineWidth = 2;
+      ctx.strokeStyle = 'rgba(184, 233, 134, ' + (0.4 + glowBoost * 0.3) + ')';
       for (const seg of network.segments) {
         const a = network.nodes[seg.from];
         const b = network.nodes[seg.to];
@@ -495,27 +598,48 @@
       ctx.restore();
 
       // All branch tips — issue #33: pulse active tip, dim inactive tips
+      // Issue #40: energy affects tip brightness and color
       const pulseT = now / 1000;
       for (let bi = 0; bi < branches.length; bi++) {
         const b = branches[bi];
         const isActive = bi === activeBranch;
         const tipX = b.growing.x;
         const tipY = b.growing.y;
+        const e = b.energy;
+        const isStarved = e <= ENERGY_STARVED_THRESHOLD;
+
+        // Issue #40: compute branch color based on energy
+        // Full energy = myceliumGlow, low = sporeGold, starved = decayViolet
+        let branchColor;
+        if (e > 0.5) {
+          branchColor = lerpColor(PALETTE.sporeGold, PALETTE.myceliumGlow, (e - 0.5) * 2);
+        } else if (e > 0.15) {
+          branchColor = lerpColor(PALETTE.decayViolet, PALETTE.sporeGold, (e - 0.15) / 0.35);
+        } else {
+          branchColor = PALETTE.decayViolet;
+        }
 
         // Draw growing segment from last node to tip
         if (b.growing.dist > 0) {
           const tipNode = network.nodes[b.tipIndex];
           ctx.save();
-          if (isActive) {
-            ctx.strokeStyle = 'rgba(184, 233, 134, ' + (0.7 + glowBoost * 0.2) + ')';
+          if (isActive && !isStarved) {
+            ctx.strokeStyle = branchColor;
+            ctx.globalAlpha = 0.7 + glowBoost * 0.2;
             ctx.shadowBlur = 10 + glowBoost * 8;
             ctx.lineWidth = 2.5;
+          } else if (isStarved) {
+            ctx.strokeStyle = PALETTE.decayViolet;
+            ctx.globalAlpha = 0.15 + 0.1 * Math.sin(pulseT * 2); // slow dim pulse
+            ctx.shadowBlur = 4;
+            ctx.lineWidth = 1;
           } else {
-            ctx.strokeStyle = 'rgba(184, 233, 134, ' + (0.2 + glowBoost * 0.05) + ')';
+            ctx.strokeStyle = branchColor;
+            ctx.globalAlpha = 0.2 + glowBoost * 0.05;
             ctx.shadowBlur = 2;
             ctx.lineWidth = 1;
           }
-          ctx.shadowColor = PALETTE.myceliumGlow;
+          ctx.shadowColor = branchColor;
           ctx.beginPath();
           ctx.moveTo(tipNode.x, tipNode.y);
           ctx.lineTo(tipX, tipY);
@@ -525,32 +649,51 @@
 
         // Tip indicator — always visible even at dist 0 (#33)
         ctx.save();
-        if (isActive) {
-          // Pulsing ring around active tip
+        if (isStarved) {
+          // Issue #40: starved tip — dim violet pulse
+          const decayPulse = 0.3 + 0.2 * Math.sin(pulseT * 1.5);
+          ctx.beginPath();
+          ctx.arc(tipX, tipY, 6 + decayPulse * 3, 0, Math.PI * 2);
+          ctx.strokeStyle = 'rgba(123, 45, 142, ' + decayPulse + ')';
+          ctx.lineWidth = 1.5;
+          ctx.shadowBlur = 8;
+          ctx.shadowColor = PALETTE.decayViolet;
+          ctx.stroke();
+
+          // Dim core
+          ctx.beginPath();
+          ctx.arc(tipX, tipY, 3, 0, Math.PI * 2);
+          ctx.fillStyle = 'rgba(123, 45, 142, ' + (decayPulse * 0.6) + ')';
+          ctx.fill();
+        } else if (isActive) {
+          // Pulsing ring around active tip — ring color reflects energy
           const pulse33 = 0.5 + 0.5 * Math.sin(pulseT * 4);
           const ringRadius = 10 + pulse33 * 6;
           ctx.beginPath();
           ctx.arc(tipX, tipY, ringRadius, 0, Math.PI * 2);
-          ctx.strokeStyle = 'rgba(184, 233, 134, ' + (0.25 + pulse33 * 0.2) + ')';
+          ctx.strokeStyle = branchColor;
+          ctx.globalAlpha = 0.25 + pulse33 * 0.2;
           ctx.lineWidth = 1.5;
           ctx.shadowBlur = 12 + pulse33 * 10;
-          ctx.shadowColor = PALETTE.myceliumGlow;
+          ctx.shadowColor = branchColor;
           ctx.stroke();
 
           // Bright core dot
+          ctx.globalAlpha = 0.95;
           ctx.beginPath();
           ctx.arc(tipX, tipY, 5, 0, Math.PI * 2);
-          ctx.fillStyle = 'rgba(184, 233, 134, 0.95)';
+          ctx.fillStyle = branchColor;
           ctx.shadowBlur = 16 + glowBoost * 10;
-          ctx.shadowColor = PALETTE.myceliumGlow;
+          ctx.shadowColor = branchColor;
           ctx.fill();
         } else {
-          // Dimmed inactive tip
+          // Dimmed inactive tip — tinted by energy
           ctx.beginPath();
           ctx.arc(tipX, tipY, 2.5, 0, Math.PI * 2);
-          ctx.fillStyle = 'rgba(184, 233, 134, 0.25)';
+          ctx.fillStyle = branchColor;
+          ctx.globalAlpha = 0.25;
           ctx.shadowBlur = 3;
-          ctx.shadowColor = PALETTE.myceliumGlow;
+          ctx.shadowColor = branchColor;
           ctx.fill();
         }
         ctx.restore();


### PR DESCRIPTION
Fixes #40

## What changed

Each branch now has an **energy** property (0.0 to 1.0) that creates resource tension:

### Energy drain
- **Idle drain** (0.015/s): all branches slowly lose energy just by existing
- **Growth drain** (0.08/s): actively growing a branch costs additional energy
- **Fork cost** (0.15): forking deducts energy from the parent branch; new branches start at 60%

### Nutrient feeding
- Collecting a nutrient replenishes **0.4 energy** to the **nearest branch** (not globally)
- This means you must strategically route branches toward nutrients to keep them alive

### Starvation effects
- At 0 energy, a branch **stops growing** — movement keys do nothing
- Starved branches **lose magnetic pull** — nutrients won't drift toward them
- Starved branches **cannot fork**
- Low-energy branches have **reduced magnetic range** (scales with energy)

### Visual feedback
- **Color gradient**: green (healthy) → gold (low) → violet (starved)
- **HUD energy bar**: shows active branch energy with color-coded fill
- **Starved tips**: slow violet pulse instead of bright green indicator
- **"STARVED" label** in the branch hint when the active branch has no energy

### Tuning constants (easy to adjust)
| Constant | Value | Purpose |
|----------|-------|---------|
| `ENERGY_DRAIN_IDLE` | 0.015/s | Background drain on all branches |
| `ENERGY_DRAIN_GROWING` | 0.08/s | Extra drain while moving |
| `ENERGY_REPLENISH` | 0.4 | Energy gained per nutrient |
| Fork cost | 0.15 | Energy deducted from parent on fork |
| New branch energy | 60% | Starting energy for forked branches |