### PR TITLE
Art: tendril depth tapering (#14)

### DIFF
--- a/game/index.html
+++ b/game/index.html
@@ -494,9 +494,43 @@
       updateEnergyBar();
     }
 
+    // --- BFS depth computation for tendril tapering (#14) ---
+    function computeNodeDepths() {
+      const depths = new Map();
+      depths.set(0, 0); // origin is depth 0
+      const adj = new Map();
+      for (const seg of network.segments) {
+        if (!adj.has(seg.from)) adj.set(seg.from, []);
+        if (!adj.has(seg.to)) adj.set(seg.to, []);
+        adj.get(seg.from).push(seg.to);
+        adj.get(seg.to).push(seg.from);
+      }
+      const queue = [0];
+      while (queue.length > 0) {
+        const cur = queue.shift();
+        for (const nb of (adj.get(cur) || [])) {
+          if (!depths.has(nb)) {
+            depths.set(nb, depths.get(cur) + 1);
+            queue.push(nb);
+          }
+        }
+      }
+      return depths;
+    }
+
+    function getMaxDepth(depths) {
+      let max = 0;
+      for (const d of depths.values()) { if (d > max) max = d; }
+      return max || 1;
+    }
+
     // --- Render ---
     function render(now) {
       const glowBoost = Math.min(score * 0.04, 0.6);
+
+      // Compute BFS depths for tapering (#14)
+      const nodeDepths = computeNodeDepths();
+      const maxDepth = getMaxDepth(nodeDepths);
 
       ctx.fillStyle = PALETTE.deepSoil;
       ctx.fillRect(0, 0, W, H);
@@ -520,11 +554,9 @@
       ctx.strokeRect(1, 1, W - 2, H - 2);
       ctx.restore();
 
-      // Network segments — bezier curves with energy-based color (issue #39 + #40)
+      // Network segments — bezier curves with depth tapering + energy color (#14, #39, #40)
       ctx.save();
-      ctx.shadowBlur = 6 + glowBoost * 12;
       ctx.shadowColor = PALETTE.myceliumGlow;
-      ctx.lineWidth = 2;
       for (const seg of network.segments) {
         const a = network.nodes[seg.from];
         const b = network.nodes[seg.to];
@@ -537,10 +569,23 @@
         const py = sdx / slen;
         const w = seg.wobble || 0;
 
+        // Depth tapering: use the deeper (further from origin) node's depth
+        const depthFrom = nodeDepths.get(seg.from) || 0;
+        const depthTo = nodeDepths.get(seg.to) || 0;
+        const segDepth = Math.max(depthFrom, depthTo);
+        const depthT = maxDepth > 0 ? segDepth / maxDepth : 0; // 0 at origin, 1 at tips
+
+        // Line width: 4px at origin, tapers to 1px at tips
+        const taperWidth = 4 - depthT * 3; // 4 -> 1
+        ctx.lineWidth = taperWidth;
+        ctx.shadowBlur = (6 + glowBoost * 12) * (1 - depthT * 0.5);
+
         const nb = nearestBranch(mx, my);
         const segEnergy = branches[nb].energy;
         const segColor = lerpColor(PALETTE.decayViolet, PALETTE.myceliumGlow, segEnergy);
-        const segAlpha = 0.2 + segEnergy * (0.2 + glowBoost * 0.3);
+        // Alpha: slight fade at extremities
+        const baseAlpha = 0.2 + segEnergy * (0.2 + glowBoost * 0.3);
+        const segAlpha = baseAlpha * (1 - depthT * 0.35);
 
         ctx.strokeStyle = segColor;
         ctx.globalAlpha = segAlpha;
@@ -567,20 +612,24 @@
           ? lerpColor(PALETTE.sporeGold, PALETTE.myceliumGlow, (e - 0.5) * 2)
           : lerpColor(PALETTE.decayViolet, PALETTE.sporeGold, e * 2);
 
-        // Growing segment from last node to tip
+        // Growing segment from last node to tip — depth-tapered (#14)
         if (b.growing.dist > 0) {
           const tipNode = network.nodes[b.tipIndex];
+          // Depth of the tip node + 1 for the growing segment (one step further out)
+          const tipDepth = (nodeDepths.get(b.tipIndex) || 0) + 1;
+          const tipDepthT = maxDepth > 0 ? Math.min(tipDepth / maxDepth, 1) : 0;
+          const growTaperWidth = 4 - tipDepthT * 3;
           ctx.save();
           if (isActive) {
             ctx.strokeStyle = tipColor;
-            ctx.globalAlpha = isStarved ? 0.3 : (0.7 + glowBoost * 0.2);
-            ctx.shadowBlur = isStarved ? 2 : (10 + glowBoost * 8);
-            ctx.lineWidth = isStarved ? 1.5 : 2.5;
+            ctx.globalAlpha = isStarved ? 0.3 : (0.7 + glowBoost * 0.2) * (1 - tipDepthT * 0.25);
+            ctx.shadowBlur = isStarved ? 2 : (10 + glowBoost * 8) * (1 - tipDepthT * 0.4);
+            ctx.lineWidth = isStarved ? Math.max(1, growTaperWidth * 0.6) : growTaperWidth;
           } else {
             ctx.strokeStyle = tipColor;
-            ctx.globalAlpha = 0.2 + e * 0.1;
+            ctx.globalAlpha = (0.2 + e * 0.1) * (1 - tipDepthT * 0.3);
             ctx.shadowBlur = 2;
-            ctx.lineWidth = 1;
+            ctx.lineWidth = Math.max(0.5, growTaperWidth * 0.5);
           }
           ctx.shadowColor = tipColor;
           const gmx = (tipNode.x + tipX) / 2;
@@ -660,20 +709,35 @@
         ctx.restore();
       }
 
-      // Network nodes
+      // Network nodes — depth-tapered size and alpha (#14)
       for (let i = 0; i < network.nodes.length; i++) {
         const n = network.nodes[i];
         const isOrigin = i === 0;
-        const r = isOrigin ? 6 : n.radius;
+        const depth = nodeDepths.get(i) || 0;
+        const depthT = maxDepth > 0 ? depth / maxDepth : 0;
+
+        // Node size: larger near origin (scale 1.0), smaller at tips (scale 0.5)
+        const depthScale = 1 - depthT * 0.5;
+        const baseR = isOrigin ? 6 : n.radius;
+        const r = baseR * depthScale;
+
+        // Alpha fade at extremities
+        const nodeAlphaScale = 1 - depthT * 0.3;
+
+        // Outer glow
         ctx.beginPath();
-        ctx.arc(n.x, n.y, r + 3, 0, Math.PI * 2);
+        ctx.arc(n.x, n.y, r + 3 * depthScale, 0, Math.PI * 2);
         ctx.fillStyle = isOrigin
           ? 'rgba(184, 233, 134, ' + (0.15 + glowBoost * 0.1) + ')'
-          : 'rgba(184, 233, 134, ' + (0.08 + glowBoost * 0.06) + ')';
+          : 'rgba(184, 233, 134, ' + ((0.08 + glowBoost * 0.06) * nodeAlphaScale) + ')';
         ctx.fill();
+
+        // Inner node
         ctx.beginPath();
         ctx.arc(n.x, n.y, r, 0, Math.PI * 2);
-        ctx.fillStyle = isOrigin ? PALETTE.myceliumGlow : 'rgba(184, 233, 134, ' + (0.6 + glowBoost * 0.3) + ')';
+        ctx.fillStyle = isOrigin
+          ? PALETTE.myceliumGlow
+          : 'rgba(184, 233, 134, ' + ((0.6 + glowBoost * 0.3) * nodeAlphaScale) + ')';
         ctx.fill();
       }
 


### PR DESCRIPTION
## Summary
- BFS from origin (node 0) computes graph depth per node each frame
- **Line width** tapers from 4px at origin to 1px at tips
- **Node size** scales down by 50% from origin to tips (depthScale: 1.0 → 0.5)
- **Alpha** fades ~35% at segment extremities, ~30% at node extremities
- Growing segments (tip-to-node) also taper based on their tip node's depth
- All existing energy-based coloring and starvation visuals preserved

## How it works
`computeNodeDepths()` runs a BFS from the origin node each render frame, building a depth map. `depthT` (0 at origin, 1 at tips) drives width, size, and alpha interpolation.

## Test plan
- [ ] Open game, grow a tendril — segments near origin should be thick (4px), tapering thinner toward the tip
- [ ] Fork multiple tendrils — each branch chain should independently taper from its shared root
- [ ] Nodes near origin appear larger; distant nodes appear smaller
- [ ] Distant segments and nodes have slightly reduced opacity
- [ ] Energy coloring (green/gold/violet) still works on top of depth tapering
- [ ] Starvation visuals unaffected