### PR TITLE
Animation: easing library, nutrient squash-and-pop, fork rejection ripple

### DIFF
--- a/game/easing.js
+++ b/game/easing.js
@@ -1,0 +1,169 @@
+/**
+ * easing.js — Animation foundation for Mycelium
+ *
+ * Easing functions, a delta-time Tween class, and helpers.
+ * Nothing in nature moves at constant speed. This module exists
+ * to make every movement feel intentional and alive.
+ *
+ * Usage:
+ *   import { easeOutQuad, Tween, tweens } from './easing.js';
+ *
+ *   // One-shot tween:
+ *   new Tween(myObj, 'scale', { from: 1, to: 1.5, duration: 200, ease: easeOutElastic });
+ *
+ *   // In your game loop:
+ *   tweens.update(dt);  // dt in seconds
+ */
+
+// --- Easing functions ---
+// All take t in [0, 1], return eased t in [0, 1] (or beyond for elastic/back).
+
+/** Decelerate — fast start, smooth stop. Best for arrivals, impacts. */
+export function easeOutQuad(t) {
+  return t * (2 - t);
+}
+
+/** Accelerate — slow start, fast end. Best for launches, growth. */
+export function easeInQuad(t) {
+  return t * t;
+}
+
+/** Smooth both ends. Best for transitions between states. */
+export function easeInOutCubic(t) {
+  return t < 0.5
+    ? 4 * t * t * t
+    : 1 - Math.pow(-2 * t + 2, 3) / 2;
+}
+
+/** Decelerate (cubic). Slightly snappier than quad. */
+export function easeOutCubic(t) {
+  return 1 - Math.pow(1 - t, 3);
+}
+
+/** Overshoot and settle — bouncy, organic. Best for pops, pickups, fork bursts. */
+export function easeOutElastic(t) {
+  if (t === 0 || t === 1) return t;
+  const c4 = (2 * Math.PI) / 3;
+  return Math.pow(2, -10 * t) * Math.sin((t * 10 - 0.75) * c4) + 1;
+}
+
+/** Overshoot slightly then return. Subtler than elastic — good for UI. */
+export function easeOutBack(t) {
+  const c1 = 1.70158;
+  const c3 = c1 + 1;
+  return 1 + c3 * Math.pow(t - 1, 3) + c1 * Math.pow(t - 1, 2);
+}
+
+/** Smooth step — no easing math, just a smooth S-curve. */
+export function smoothstep(t) {
+  return t * t * (3 - 2 * t);
+}
+
+/** Linear — the enemy. Only use when you genuinely need constant speed. */
+export function linear(t) {
+  return t;
+}
+
+// --- Lerp helper ---
+export function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+// --- Tween class ---
+
+/**
+ * Animates a single property on a target object.
+ *
+ * @param {object} target - The object whose property to animate
+ * @param {string} prop - Property name on target
+ * @param {object} opts
+ * @param {number} opts.from - Start value (defaults to current value)
+ * @param {number} opts.to - End value
+ * @param {number} opts.duration - Duration in ms
+ * @param {function} [opts.ease=easeOutQuad] - Easing function
+ * @param {function} [opts.onUpdate] - Called each tick with (value, t)
+ * @param {function} [opts.onComplete] - Called when tween finishes
+ * @param {number} [opts.delay=0] - Delay before starting, in ms
+ */
+export class Tween {
+  constructor(target, prop, opts = {}) {
+    this.target = target;
+    this.prop = prop;
+    this.from = opts.from !== undefined ? opts.from : target[prop];
+    this.to = opts.to;
+    this.duration = opts.duration || 200; // ms
+    this.ease = opts.ease || easeOutQuad;
+    this.onUpdate = opts.onUpdate || null;
+    this.onComplete = opts.onComplete || null;
+    this.delay = opts.delay || 0;
+    this.elapsed = -this.delay; // negative = waiting through delay
+    this.done = false;
+
+    // Auto-register
+    tweens.add(this);
+  }
+
+  /** Advance by dt (seconds). Returns true if still active. */
+  tick(dt) {
+    if (this.done) return false;
+
+    this.elapsed += dt * 1000; // convert to ms
+
+    if (this.elapsed < 0) return true; // still in delay
+
+    const progress = Math.min(this.elapsed / this.duration, 1);
+    const easedT = this.ease(progress);
+    const value = lerp(this.from, this.to, easedT);
+
+    this.target[this.prop] = value;
+    if (this.onUpdate) this.onUpdate(value, easedT);
+
+    if (progress >= 1) {
+      this.done = true;
+      this.target[this.prop] = this.to; // snap to exact end value
+      if (this.onComplete) this.onComplete();
+      return false;
+    }
+
+    return true;
+  }
+}
+
+// --- Tween Manager ---
+
+class TweenManager {
+  constructor() {
+    this._tweens = [];
+  }
+
+  add(tween) {
+    this._tweens.push(tween);
+  }
+
+  /** Update all active tweens. Call once per frame with dt in seconds. */
+  update(dt) {
+    for (let i = this._tweens.length - 1; i >= 0; i--) {
+      const alive = this._tweens[i].tick(dt);
+      if (!alive) {
+        this._tweens.splice(i, 1);
+      }
+    }
+  }
+
+  /** Number of active tweens (useful for profiling). */
+  get count() {
+    return this._tweens.length;
+  }
+
+  /** Kill all tweens on a specific target (e.g., when a nutrient is removed). */
+  killTarget(target) {
+    for (let i = this._tweens.length - 1; i >= 0; i--) {
+      if (this._tweens[i].target === target) {
+        this._tweens.splice(i, 1);
+      }
+    }
+  }
+}
+
+/** Global tween manager — import and call tweens.update(dt) in your game loop. */
+export const tweens = new TweenManager();

--- a/game/index.html
+++ b/game/index.html
@@ -203,6 +203,7 @@
 
     import { spawnBurst, updateParticles, renderParticles } from './particles.js';
     import { createCompetingFungus, updateCompetingFungus, renderCompetingFungus } from './ai.js';
+    import { easeOutQuad, easeOutElastic, easeOutCubic, easeInQuad, Tween, tweens } from './easing.js';
 
     // --- Accessibility: reduced motion + screen reader ---
     const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -456,14 +457,135 @@
 
     for (let i = 0; i < NUTRIENT_COUNT; i++) spawnNutrient(i < 4);
 
+    // --- Fork-rejection ripple (issue #48: denied fork feedback) ---
+    const forkRipples = []; // {x, y, age, duration, color}
+
+    function spawnForkRipple(x, y, reason) {
+      if (prefersReducedMotion) return;
+      const color = reason === 'energy' ? PALETTE.decayViolet : PALETTE.rootAmber;
+      forkRipples.push({ x, y, age: 0, duration: 0.4, color, maxRadius: 24 });
+    }
+
+    function updateForkRipples(dt) {
+      for (let i = forkRipples.length - 1; i >= 0; i--) {
+        forkRipples[i].age += dt;
+        if (forkRipples[i].age >= forkRipples[i].duration) {
+          forkRipples.splice(i, 1);
+        }
+      }
+    }
+
+    function renderForkRipples() {
+      for (const r of forkRipples) {
+        const t = r.age / r.duration;
+        const easedT = easeOutCubic(t);
+        const radius = r.maxRadius * easedT;
+        const alpha = (1 - easedT) * 0.6;
+        ctx.save();
+        ctx.beginPath();
+        ctx.arc(r.x, r.y, radius, 0, Math.PI * 2);
+        ctx.strokeStyle = r.color;
+        ctx.globalAlpha = alpha;
+        ctx.lineWidth = 2 * (1 - easedT);
+        ctx.shadowBlur = 6;
+        ctx.shadowColor = r.color;
+        ctx.stroke();
+        ctx.restore();
+      }
+    }
+
+    // --- Nutrient absorption animation (squash-and-pop) ---
+    const absorptionAnims = []; // {x, y, age, duration, color}
+
+    function spawnAbsorptionAnim(x, y) {
+      if (prefersReducedMotion) return;
+      absorptionAnims.push({
+        x, y, age: 0, duration: 0.3,
+        // Three phases: scale up (80ms), squish (60ms), pop out (160ms)
+      });
+    }
+
+    function updateAbsorptionAnims(dt) {
+      for (let i = absorptionAnims.length - 1; i >= 0; i--) {
+        absorptionAnims[i].age += dt;
+        if (absorptionAnims[i].age >= absorptionAnims[i].duration) {
+          absorptionAnims.splice(i, 1);
+        }
+      }
+    }
+
+    function renderAbsorptionAnims() {
+      for (const a of absorptionAnims) {
+        const t = a.age / a.duration;
+
+        // Phase 1 (0-0.27): scale up with slight overshoot
+        // Phase 2 (0.27-0.47): squish horizontally, stretch vertically
+        // Phase 3 (0.47-1.0): pop outward and fade
+        let scaleX, scaleY, alpha;
+
+        if (t < 0.27) {
+          const pt = t / 0.27;
+          const eased = easeOutBack(pt);
+          scaleX = scaleY = 1 + eased * 0.5; // grows to 1.5x
+          alpha = 0.8;
+        } else if (t < 0.47) {
+          const pt = (t - 0.27) / 0.2;
+          const eased = easeOutQuad(pt);
+          scaleX = 1.5 - eased * 0.8; // squish to 0.7x wide
+          scaleY = 1.5 + eased * 0.3; // stretch to 1.8x tall
+          alpha = 0.7;
+        } else {
+          const pt = (t - 0.47) / 0.53;
+          const eased = easeInQuad(pt);
+          scaleX = scaleY = (0.7 + eased * 1.3); // expand outward
+          alpha = (1 - eased) * 0.6; // fade out
+        }
+
+        ctx.save();
+        ctx.translate(a.x, a.y);
+        ctx.scale(scaleX, scaleY);
+        ctx.beginPath();
+        ctx.arc(0, 0, NUTRIENT_RADIUS + 2, 0, Math.PI * 2);
+        ctx.fillStyle = PALETTE.sporeGold;
+        ctx.globalAlpha = alpha;
+        ctx.shadowBlur = 12 * alpha;
+        ctx.shadowColor = PALETTE.sporeGold;
+        ctx.fill();
+        ctx.restore();
+
+        // Ring burst that expands outward
+        if (t > 0.2) {
+          const ringT = (t - 0.2) / 0.8;
+          const ringEased = easeOutCubic(ringT);
+          ctx.save();
+          ctx.beginPath();
+          ctx.arc(a.x, a.y, (COLLECT_RADIUS * 0.3) + ringEased * COLLECT_RADIUS * 0.7, 0, Math.PI * 2);
+          ctx.strokeStyle = PALETTE.sporeGold;
+          ctx.globalAlpha = (1 - ringEased) * 0.4;
+          ctx.lineWidth = 1.5 * (1 - ringEased);
+          ctx.shadowBlur = 8;
+          ctx.shadowColor = PALETTE.sporeGold;
+          ctx.stroke();
+          ctx.restore();
+        }
+      }
+    }
+
     // --- Branching (issue #23) ---
     function createBranch() {
       if (!gameStarted) return;
       const now = performance.now();
       const current = branches[activeBranch];
-      if (current.growing.dist < BRANCH_MIN_DIST || (now - lastBranchTime) < BRANCH_COOLDOWN) return;
+      // Fork rejection feedback (issue #48)
+      if (current.growing.dist < BRANCH_MIN_DIST || (now - lastBranchTime) < BRANCH_COOLDOWN) {
+        spawnForkRipple(current.growing.x, current.growing.y, 'cooldown');
+        return;
+      }
       // Energy gate: forking costs energy (issue #40)
-      if (current.energy < ENERGY_FORK_COST) return;
+      if (current.energy < ENERGY_FORK_COST) {
+        spawnForkRipple(current.growing.x, current.growing.y, 'energy');
+        return;
+      }
       lastBranchTime = now;
       current.energy -= ENERGY_FORK_COST;
       if (current.growing.dist > 5) {
@@ -596,6 +718,9 @@
       updateParticles(dt);
       updateMilestones(dt);
       updateEnergyBar();
+      tweens.update(dt);
+      updateForkRipples(dt);
+      updateAbsorptionAnims(dt);
 
       // --- Magnetic nutrient pull — energy reduces range ---
       for (const n of nutrients) {
@@ -671,7 +796,10 @@
 
     function collectNutrient(index, nx, ny) {
       const collected = nutrients[index];
-      if (!prefersReducedMotion) spawnBurst(collected.x, collected.y, PALETTE.sporeGold);
+      if (!prefersReducedMotion) {
+        spawnBurst(collected.x, collected.y, PALETTE.sporeGold);
+        spawnAbsorptionAnim(collected.x, collected.y);
+      }
       nutrients.splice(index, 1);
       score++;
       scoreEl.textContent = 'Absorbed: ' + score;
@@ -992,6 +1120,8 @@
       }
 
       renderParticles(ctx);
+      renderAbsorptionAnims();
+      renderForkRipples();
       renderMilestones();
     }
 


### PR DESCRIPTION
## What this does

Adds an animation foundation (`game/easing.js`) and applies it to the two interactions that feel most lifeless right now: nutrient collection and fork rejection.

### easing.js — the animation toolkit

8 standard easing curves, a `Tween` class, and a `TweenManager` singleton. Usage:

```js
import { easeOutElastic, Tween, tweens } from './easing.js';

new Tween(myObj, 'scale', { from: 1, to: 1.5, duration: 200, ease: easeOutElastic });

// In game loop:
tweens.update(dt);
```

All tweens are framerate-independent (delta-time), auto-register, and self-cleanup.

### Nutrient absorption: squash-and-pop

When a tendril absorbs a nutrient, instead of just a particle burst:
1. **Scale up** to 1.5x over 80ms with `easeOutBack` overshoot
2. **Squish** horizontally to 0.7x, stretch vertically to 1.8x over 60ms
3. **Pop** outward and fade over 160ms with expanding ring

Total: 300ms. The network feels like it's *eating*. The existing particle burst still fires alongside this.

### Fork rejection ripple (fixes #48)

When Space is pressed but fork is denied:
- **Cooldown/distance**: amber ripple expands from tip (400ms, `easeOutCubic`)
- **Insufficient energy**: violet ripple — color matches the energy bar's danger state

Players now get immediate, intuitive feedback instead of confusing silence.

### Respects a11y

All new animations check `prefers-reduced-motion` and skip if set. Same pattern as existing animations.

## Timing rationale

| Animation | Duration | Easing | Why |
|-----------|----------|--------|-----|
| Absorption scale-up | 80ms | easeOutBack | Snappy impact with slight overshoot |
| Absorption squish | 60ms | easeOutQuad | Quick settle after impact |
| Absorption pop | 160ms | easeInQuad | Accelerating dispersal |
| Fork rejection ripple | 400ms | easeOutCubic | Visible but not dramatic — it's a "no" |

## Files changed

- **`game/easing.js`** (new) — easing functions, Tween class, TweenManager
- **`game/index.html`** — import easing, add absorption + ripple systems, wire into update/render loops, add fork rejection feedback to `createBranch()`

Closes #48