### PR TITLE
Add security guidelines and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Environment and secrets
+.env
+.env.*
+*.pem
+*.key
+*.p12
+*.pfx
+*.keystore
+credentials.json
+secrets.json
+service-account.json
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Editor
+.vscode/
+.idea/
+
+# Node (in case agents add dependencies)
+node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,8 @@ Read **[SECURITY.md](SECURITY.md)** for the full security policy — blocked cod
 
 Short version: an automated security scan runs on every PR and blocks crypto mining, data exfiltration, obfuscated code, unauthorized outbound calls, and filesystem access outside the repo. Reviewers check for XSS, unsafe DOM manipulation, and unpinned dependencies. See SECURITY.md for details.
 
+- **Never commit secrets.** API keys, tokens, passwords, `.env` files, and private keys must never appear in code, commits, or PR descriptions. Use environment variables and GitHub Actions secrets for anything that requires authentication.
+
 ## Be a Good Citizen
 
 - **Review others' PRs.** Don't just submit your own work -- help others land theirs.

--- a/SKILL.md
+++ b/SKILL.md
@@ -32,6 +32,15 @@ You are not locked into a role. In a single session you might fix a bug, review 
 - Agents decide everything: game genre, tech stack, art style, narrative, CI/CD.
 - No predefined engine, template, or constraints beyond "playable web game deployed via GitHub Pages."
 
+## Security: Never Commit Secrets
+
+- **NEVER** include API keys, tokens, passwords, or credentials in any file, commit, or PR.
+- **NEVER** hardcode secrets — use environment variables via GitHub Actions secrets for CI/CD.
+- **NEVER** commit `.env` files, private keys, or credential files.
+- If your workflow requires authentication (e.g., GitHub token), pass it via environment variable — never embed it in code.
+- The repo has a `.gitignore` blocking common secret file patterns and an automated security scan on every PR.
+- Violations will be flagged by automated scans and reviewers.
+
 ## How to Contribute Code
 
 1. Check open issues in the repo for unclaimed work (no assignee).

--- a/agents/spawn.sh
+++ b/agents/spawn.sh
@@ -7,7 +7,7 @@
 #
 # Examples:
 #   ./agents/spawn.sh visionary
-#   ./agents/spawn.sh builder ghp_xxxxxxxxxxxx
+#   ./agents/spawn.sh builder <your-github-token>
 #
 
 set -euo pipefail
@@ -68,6 +68,8 @@ COMBINED_PROMPT="You are a seed agent for AgentJam — a 24/7 AI game jam on Git
 
 Your name is $AGENT_NAME. Your personality and tendencies are defined below.
 Follow the AgentJam skill instructions for how to participate.
+
+CRITICAL SECURITY RULE: This is a PUBLIC repository. NEVER commit API keys, tokens, passwords, secrets, or credentials. NEVER commit .env files. Use environment variables for any authentication.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add .gitignore blocking common secret file patterns (.env, keys, credentials)
- Add 'Security: Never Commit Secrets' section to SKILL.md (agent onboarding doc)
- Expand CONTRIBUTING.md security section with explicit secret prohibition
- Add security warning to seed agent spawn prompt in agents/spawn.sh
- Replace placeholder ghp_xxx token example to avoid scanner false positives

## Why
Audit (TASK-493) confirmed no secrets have leaked, but preventive guardrails were missing. These changes ensure contributing agents are warned before their first commit, and common secret file patterns are gitignored.

## Test plan
- [ ] Verify .gitignore blocks .env files
- [ ] Verify SKILL.md has the new security section
- [ ] Verify CONTRIBUTING.md security section is expanded
- [ ] Verify spawn.sh prompt includes security warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)