### PR TITLE
Hide intermediate tendril nodes for organic feel

### DIFF
--- a/game/index.html
+++ b/game/index.html
@@ -1036,36 +1036,53 @@
         ctx.restore();
       }
 
-      // Network nodes — depth-tapered size and alpha (#14)
+      // Network nodes — only render origin + fork points (#64: hide intermediate nodes)
+      // Compute connectivity: count how many segments each node participates in
+      const nodeConnections = new Map();
+      for (const seg of network.segments) {
+        nodeConnections.set(seg.from, (nodeConnections.get(seg.from) || 0) + 1);
+        nodeConnections.set(seg.to, (nodeConnections.get(seg.to) || 0) + 1);
+      }
+      // Collect active tip node indices so we can skip them (tips have their own rendering above)
+      const tipNodeIndices = new Set(branches.map(b => b.tipIndex));
+
       for (let i = 0; i < network.nodes.length; i++) {
         const n = network.nodes[i];
         const isOrigin = i === 0;
+        const isFork = (nodeConnections.get(i) || 0) >= 3; // 3+ connections = branch junction
+        const isTip = tipNodeIndices.has(i);
+
+        // Skip intermediate nodes entirely — they are just segment junctions (#64)
+        if (!isOrigin && !isFork) continue;
+        // Skip tip nodes — they already have dedicated tip rendering above
+        if (isTip && !isOrigin) continue;
+
         const depth = nodeDepths.get(i) || 0;
         const depthT = maxDepth > 0 ? depth / maxDepth : 0;
-
-        // Node size: larger near origin (scale 1.0), smaller at tips (scale 0.5)
         const depthScale = 1 - depthT * 0.5;
-        const baseR = isOrigin ? 6 : n.radius;
-        const r = baseR * depthScale;
 
-        // Alpha fade at extremities
-        const nodeAlphaScale = 1 - depthT * 0.3;
-
-        // Outer glow
-        ctx.beginPath();
-        ctx.arc(n.x, n.y, r + 3 * depthScale, 0, Math.PI * 2);
-        ctx.fillStyle = isOrigin
-          ? 'rgba(184, 233, 134, ' + (0.15 + glowBoost * 0.1) + ')'
-          : 'rgba(184, 233, 134, ' + ((0.08 + glowBoost * 0.06) * nodeAlphaScale) + ')';
-        ctx.fill();
-
-        // Inner node
-        ctx.beginPath();
-        ctx.arc(n.x, n.y, r, 0, Math.PI * 2);
-        ctx.fillStyle = isOrigin
-          ? PALETTE.myceliumGlow
-          : 'rgba(184, 233, 134, ' + ((0.6 + glowBoost * 0.3) * nodeAlphaScale) + ')';
-        ctx.fill();
+        if (isOrigin) {
+          // Origin: prominent glow — the heart of the network
+          ctx.beginPath();
+          ctx.arc(n.x, n.y, 9 * depthScale, 0, Math.PI * 2);
+          ctx.fillStyle = 'rgba(184, 233, 134, ' + (0.15 + glowBoost * 0.1) + ')';
+          ctx.fill();
+          ctx.beginPath();
+          ctx.arc(n.x, n.y, 6 * depthScale, 0, Math.PI * 2);
+          ctx.fillStyle = PALETTE.myceliumGlow;
+          ctx.fill();
+        } else if (isFork) {
+          // Fork points: subtle organic knot — just a soft glow, no hard dot
+          const forkAlpha = (0.12 + glowBoost * 0.08) * (1 - depthT * 0.4);
+          ctx.save();
+          ctx.beginPath();
+          ctx.arc(n.x, n.y, 4 * depthScale, 0, Math.PI * 2);
+          ctx.fillStyle = 'rgba(184, 233, 134, ' + forkAlpha + ')';
+          ctx.shadowBlur = 6;
+          ctx.shadowColor = PALETTE.myceliumGlow;
+          ctx.fill();
+          ctx.restore();
+        }
       }
 
       // Nutrients with collection radius hint + magnetic drift trail


### PR DESCRIPTION
## Summary

- **Removes green dots at every segment junction** — intermediate nodes along tendril paths are no longer rendered, eliminating the connect-the-dots / circuit-node appearance
- **Origin node preserved** with its existing prominent glow (the heart of the network)
- **Fork points rendered as soft glows** — nodes with 3+ segment connections get a subtle organic knot instead of a hard dot, with depth-based fade
- **Tip nodes excluded from the loop** to avoid double-drawing (they already have dedicated pulsing ring + energy color rendering)

## How it works

A connectivity map is computed each frame: for each node, count how many segments reference it. Nodes with < 3 connections are intermediate junctions and are skipped entirely. The origin (index 0) always renders. Fork points (3+ connections) get a softened glow that fades with depth.

## Visual impact

Before: Every segment boundary has a visible green dot → network looks like a wiring diagram with solder points

After: Tendrils read as continuous organic threads. Only the origin and branch junctions are marked, and branch junctions use a soft glow rather than a hard circle.

Combined with the existing bezier curve rendering, this should make a meaningful step toward the biological feel described in #14 (art direction).

Closes #64

🎨 Generated with [Claude Code](https://claude.com/claude-code)