### PR TITLE
Restrict magnetic nutrient pull to active branch and shrink detection radius

### DIFF
--- a/game/constants.js
+++ b/game/constants.js
@@ -21,7 +21,7 @@ export const BRANCH_COOLDOWN = 200; // issue #32: ms cooldown between branches
 export const NUTRIENT_COUNT = 8;
 export const NUTRIENT_RADIUS = 5;
 export const COLLECT_RADIUS = 35; // issue #22: generous collision (was ~13px)
-export const MAGNETIC_RADIUS = 130; // chemical gradient range — nutrients start drifting
+export const MAGNETIC_RADIUS = 70; // issue #90: reduced from 130 — player must get closer before pull kicks in
 export const MAGNETIC_STRENGTH = 180; // base pull force (px/s^2)
 export const MAGNETIC_DAMPING = 0.92; // velocity damping per frame (keeps motion smooth)
 

--- a/game/index.html
+++ b/game/index.html
@@ -722,20 +722,21 @@
       updateForkRipples(dt);
       updateAbsorptionAnims(dt);
 
-      // --- Magnetic nutrient pull — energy reduces range ---
+      // --- Magnetic nutrient pull — active branch only (issue #90) ---
       for (const n of nutrients) {
         let closestDist = Infinity;
         let pullDx = 0, pullDy = 0;
         let pullBranchEnergy = 1;
 
-        for (const b of branches) {
-          const d = dist(n.x, n.y, b.growing.x, b.growing.y);
-          const effectiveRadius = MAGNETIC_RADIUS * Math.max(0.2, b.energy);
-          if (d < effectiveRadius && d < closestDist && d > 1) {
+        const ab = branches[activeBranch];
+        if (ab && ab.energy > ENERGY_STARVED_THRESHOLD) {
+          const d = dist(n.x, n.y, ab.growing.x, ab.growing.y);
+          const effectiveRadius = MAGNETIC_RADIUS * Math.max(0.2, ab.energy);
+          if (d < effectiveRadius && d > 1) {
             closestDist = d;
-            pullDx = (b.growing.x - n.x) / d;
-            pullDy = (b.growing.y - n.y) / d;
-            pullBranchEnergy = b.energy;
+            pullDx = (ab.growing.x - n.x) / d;
+            pullDy = (ab.growing.y - n.y) / d;
+            pullBranchEnergy = ab.energy;
           }
         }
 
@@ -771,11 +772,7 @@
           }
         }
         if (collected) continue;
-        for (const node of network.nodes) {
-          if (dist(node.x, node.y, n.x, n.y) < n.radius + node.radius + 15) {
-            collectNutrient(i, node.x, node.y); break;
-          }
-        }
+        // Node-based collection removed (issue #90) — only tips absorb nutrients
       }
 
       // --- Update AI fungi (#78) ---


### PR DESCRIPTION
The magnetic nutrient-pull loop in `game/index.html` previously iterated over *every* branch tip, meaning nutrients drifted toward whichever tip happened to be closest — the player could sit still and still hoover up most of the field. This change scopes the pull calculation to `branches[activeBranch]` only, so nutrients are attracted exclusively toward the tip the player is currently steering. On top of that, the loop now short-circuits entirely when the active branch's energy is at or below `ENERGY_STARVED_THRESHOLD`, which means a starving branch can no longer passively collect — the player has to grow toward the nutrient first. The old "node-based collection" fallback (the inner `network.nodes` proximity check) is also removed; only genuine branch tips absorb nutrients now, eliminating the silent safety-net that made precise steering unnecessary.

In `game/constants.js`, `MAGNETIC_RADIUS` drops from 130 px to 70 px. The previous radius was generous enough that nutrients would start sliding toward you almost a full branch-length away; halving it forces the player to commit to a direction and close the gap before the pull kicks in. Combined with the active-branch-only restriction above, the result is a tighter, more intentional collection loop where steering decisions actually matter. The `COLLECT_RADIUS` (35 px) and `MAGNETIC_STRENGTH` (180) are left untouched — the feel of the pull once you *are* in range stays the same, so the change targets engagement without making collection frustrating.

The design intent is to reintroduce micro-decisions into nutrient gathering: the player now picks *which* nutrient to chase and *when* to commit, rather than passively benefiting from a wide dragnet across all tips. I verified locally by running the game in-browser, confirming that nutrients no longer drift toward inactive branches, that the pull only activates within the reduced 70 px radius, and that a starved branch stops attracting entirely — no console errors or regressions in the growth or fork-ripple systems.

Closes https://github.com/shineli1984/agent-jam/issues/58