### PR TITLE
Archivist: decision log + timeline update (PRs #88–101)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -184,6 +184,80 @@ Every major project decision, with rationale, alternatives considered, and links
 
 ---
 
+## ADR-013: Node rendering — hide intermediates, soften forks
+
+**Decision:** Intermediate junction nodes along tendril paths are no longer rendered. Only the origin node (with its prominent glow) and fork points (3+ segment connections) are drawn. Fork points use a soft depth-faded glow instead of a hard dot. Tip nodes are excluded entirely (they already have dedicated pulsing ring rendering).
+
+**How it works:** A connectivity map is computed each frame — for each node, count how many segments reference it. Nodes with fewer than 3 connections are skipped. Fork points get a softened glow that fades with depth.
+
+**Rationale:** The green dots at every segment junction made the network look like a connect-the-dots wiring diagram with solder points. Removing them makes tendrils read as continuous organic threads, complementing the bezier curve rendering from ADR-004.
+
+**Discussion:** [#64](https://github.com/shineli1984/agent-jam/issues/64) (problem), [PR #88](https://github.com/shineli1984/agent-jam/pull/88) (implementation)
+
+---
+
+## ADR-014: Segment ownership — O(1) branch lookup, not O(n*m) search
+
+**Decision:** Each segment stores its owning `branch` index at creation time. The render loop uses `seg.branch` directly instead of calling `nearestBranch()` per segment per frame.
+
+**Prior state:** `nearestBranch()` iterated all branches for every segment during render. With 100 segments and 10 branches, that was 1,000 distance calculations per frame just for coloring.
+
+**Rationale:** Pure performance fix. Zero visual change. The old approach scaled poorly as networks grew — this makes branch coloring O(1) per segment regardless of branch count.
+
+**Discussion:** [#69](https://github.com/shineli1984/agent-jam/issues/69) (perf issue), [PR #89](https://github.com/shineli1984/agent-jam/pull/89) (fix)
+
+---
+
+## ADR-015: Nutrient collection — active branch only, tighter radius
+
+**Decision:** Magnetic nutrient pull now applies only to the active branch tip (the one the player is currently steering), not all branch tips. Magnetic radius reduced from 130px to 70px. Starved branches cannot attract nutrients at all. The old "node-based collection" fallback (inner `network.nodes` proximity check) was removed.
+
+**Prior state:** Nutrients drifted toward whichever branch tip was closest, regardless of which one the player was steering. The 130px radius was generous enough that nutrients would start sliding toward you almost a full branch-length away. Players could sit still and passively collect most of the field.
+
+**Rationale:** Reintroduces micro-decisions into nutrient gathering. The player now picks *which* nutrient to chase and *when* to commit, rather than passively benefiting from a wide dragnet across all tips. `COLLECT_RADIUS` (35px) and `MAGNETIC_STRENGTH` (180) were left untouched — the feel of the pull once you are in range stays the same.
+
+**Discussion:** [#58](https://github.com/shineli1984/agent-jam/issues/58) (magnetic pull too passive), [PR #92](https://github.com/shineli1984/agent-jam/pull/92) (implementation)
+
+---
+
+## ADR-016: Gatekeeper removed — human review over automated bot
+
+**Decision:** The automated gatekeeper (`gatekeeper.yml` + `gatekeeper.js`) was removed entirely. CODEOWNERS + required human review are now the sole merge-time security gate. The security scan workflow was switched to `pull_request_target` so it runs on fork PRs without manual workflow approval.
+
+**Prior state:** An OpenAI GPT-4o-mini powered bot reviewed every PR, issue, and comment, plus ran on a 15-minute cron. Fork PRs showed "2 workflows awaiting approval," blocking CI.
+
+**Rationale:** The gatekeeper cost OpenAI tokens continuously with minimal value when the repo owner reviews everything. The security scan (grep for literal strings) was easily gamed. Fork contributors were blocked from getting any CI feedback. The gatekeeper couldn't work on fork PRs anyway (secrets unavailable).
+
+**Note:** This reverses ADR-010 (gatekeeper infrastructure). The decision to use OpenAI GPT-4o-mini is now moot — there is no automated reviewer.
+
+**Discussion:** [PR #93](https://github.com/shineli1984/agent-jam/pull/93)
+
+---
+
+## ADR-017: Nutrient spawning — cluster-seeded, not uniform random
+
+**Decision:** Nutrients spawn around 3-5 procedurally placed cluster seeds (one per canvas quadrant + optional center seed) with gaussian-ish falloff (30-90px radius). Respawned nutrients bias toward the nearest cluster seed. 15% of spawns are "wild" (fully random) to prevent total predictability.
+
+**Prior state:** Nutrients spawned at completely random positions on collection. Every game felt the same.
+
+**Rationale:** Cluster-based spawning creates emergent layout archetypes (dual cluster, ring, motherlode, corridor) that give each playthrough a unique strategic landscape. The AI's existing utility scoring naturally adapts to cluster layouts with zero AI code changes. Origin-spawned nutrients reduced from 4 to 2 to give players a directional incentive from the start.
+
+**Discussion:** [#80](https://github.com/shineli1984/agent-jam/issues/80) (proposal), [PR #100](https://github.com/shineli1984/agent-jam/pull/100) (implementation)
+
+---
+
+## ADR-018: Growth dynamics — velocity-based with easing, not fixed-step
+
+**Decision:** Tendril growth uses a velocity-based system with acceleration (~120ms ramp-up) and deceleration (~180ms drift-to-stop) instead of fixed-step linear growth (`growSpeed * dt`). Each branch tracks `currentSpeed`, `lastDx`, `lastDy`. Tips drift 3-5px on key release before settling.
+
+**Prior state:** Growth was `growSpeed * dt` — instant full speed on key press, instant stop on release. Movement felt mechanical.
+
+**Rationale:** The single biggest game-feel improvement. Tendrils now move like they are alive instead of marching at constant speed. The overshoot on release creates organic arcs on quick direction changes. No gameplay mechanics were changed — only the step-size computation.
+
+**Discussion:** [#82](https://github.com/shineli1984/agent-jam/issues/82) (tendril easing request), [PR #101](https://github.com/shineli1984/agent-jam/pull/101) (implementation)
+
+---
+
 ## Implicit decisions (not formally debated)
 
 These choices were made by whoever built the feature first. They have not been challenged, but they also have no recorded rationale. If you want to change one of these, check the linked PR for context before proposing an alternative.
@@ -192,9 +266,9 @@ These choices were made by whoever built the feature first. They have not been c
 |----------|--------------|---------------|
 | Arrow keys + WASD for movement | Works, but click-to-grow is the north star | [PR #6](https://github.com/shineli1984/agent-jam/pull/6) |
 | 960x640 internal canvas resolution | Does not scale to viewport; letterboxed on large screens | [PR #20](https://github.com/shineli1984/agent-jam/pull/20) |
-| Nutrients spawn at random positions on collection | No cluster-based or procedural placement | [PR #29](https://github.com/shineli1984/agent-jam/pull/29) |
+| ~~Nutrients spawn at random positions on collection~~ | Replaced by cluster-based spawning in ADR-017 | ~~[PR #29](https://github.com/shineli1984/agent-jam/pull/29)~~ → [PR #100](https://github.com/shineli1984/agent-jam/pull/100) |
 | Edge bounce (tendrils redirect on hitting canvas boundary) | Creates geometric zigzag ([#46](https://github.com/shineli1984/agent-jam/issues/46)) | [PR #42](https://github.com/shineli1984/agent-jam/pull/42) |
-| Magnetic pull radius of 35px | Debated as too passive ([#58](https://github.com/shineli1984/agent-jam/issues/58)) | [PR #36](https://github.com/shineli1984/agent-jam/pull/36) |
+| ~~Magnetic pull radius of 130px~~ | Reduced to 70px and scoped to active branch only in ADR-015 | ~~[PR #36](https://github.com/shineli1984/agent-jam/pull/36)~~ → [PR #92](https://github.com/shineli1984/agent-jam/pull/92) |
 | Title screen dismissed by any keypress | No click/touch support documented | [PR #35](https://github.com/shineli1984/agent-jam/pull/35) |
 | Timelapse replay triggered by Escape key | No UI button; discoverability concern | [PR #68](https://github.com/shineli1984/agent-jam/pull/68) |
 | "Mycelium" as the name | Critic and storyteller both flagged this as a biology term most players won't know; "Undergrowth" was suggested | [#4](https://github.com/shineli1984/agent-jam/issues/4) |
@@ -207,7 +281,9 @@ These have been raised in discussions but not settled:
 
 1. **Click-to-grow vs arrow keys** — The design doc says click-to-grow. The game uses arrow keys. When does the pivot happen? ([#12](https://github.com/shineli1984/agent-jam/issues/12))
 2. **Game name** — "Mycelium" or something more accessible? "Undergrowth," "Root," "Sprawl" were suggested. ([#4](https://github.com/shineli1984/agent-jam/issues/4))
-3. **Game-over condition** — Total network starvation? AI wins? Timed? Self-determined? ([#13](https://github.com/shineli1984/agent-jam/issues/13))
+3. **Game-over condition** — Partially resolved: total network starvation now triggers a "THE NETWORK WITHERS" game-over screen with stats and restart ([PR #98](https://github.com/shineli1984/agent-jam/pull/98)). But: what about AI winning? Timed modes? Victory conditions? ([#13](https://github.com/shineli1984/agent-jam/issues/13))
 4. **Trees and symbiosis/parasitism** — The central design choice from #12, entirely unbuilt. How does the player interact with trees? ([#12](https://github.com/shineli1984/agent-jam/issues/12))
 5. **Fog of war / darkness reveal** — Act 1 of the narrative framework depends on this. Not started. ([#13](https://github.com/shineli1984/agent-jam/issues/13))
 6. **Responsive canvas** — The 960x640 internal resolution doesn't scale. Full viewport rendering or CSS scaling? ([#14](https://github.com/shineli1984/agent-jam/issues/14) comments)
+7. **Tab key hijacks browser navigation** — Tab is used for branch switching but traps keyboard-only users inside the game. Needs an alternative keybinding or escape mechanism. ([#99](https://github.com/shineli1984/agent-jam/issues/99))
+8. **New player onboarding** — No sense of direction or goal in the first 10 seconds. Players don't know what to do or why. ([#96](https://github.com/shineli1984/agent-jam/issues/96))

--- a/TIMELINE.md
+++ b/TIMELINE.md
@@ -2,7 +2,7 @@
 
 A chronological record of how Mycelium got built. Every milestone, pivot, and significant event, with links to the original discussions and PRs.
 
-All events occurred on **2026-03-26** — this entire game was built in a single day by AI agents.
+Development began on **2026-03-26** and continued into **2026-03-27** — this game was built in two days by AI agents.
 
 ---
 
@@ -124,20 +124,55 @@ All events occurred on **2026-03-26** — this entire game was built in a single
 
 ---
 
-## What exists now (end of day)
+## Phase 7: Refinement and game feel (evening into night)
 
-23 PRs merged. A playable game with:
-- Bezier-curve tendril growth with depth tapering
-- Branching with energy cost and strategic forking
+**PR #88** — Intermediate tendril nodes hidden. The green dots at every segment junction — making the network look like a connect-the-dots diagram — were removed. Only the origin and fork junctions are now drawn, with fork points rendered as soft depth-faded glows. Combined with the existing bezier curves, this is the final piece of the "organic tendril" visual pipeline.
+
+**PR #89** — Render performance fix. `nearestBranch()` was being called per-segment per frame (O(n*m)). Segments now store their branch index at creation time — O(1) lookup. Zero visual change, significant performance improvement as networks grow.
+
+**#90** — "Welcome to AgentJam" onboarding issue created — a contributor-facing guide to the project.
+
+**#91** — Music direction issue opened: generative soundtrack design for a living network. Audio remains the one entirely unbuilt dimension.
+
+**PR #92** — Magnetic nutrient pull tightened. Radius halved from 130px to 70px and scoped to active branch only. Starved branches can no longer passively collect. This was the gameplay tuning answer to #58 ("magnetic pull too passive") — counter-intuitively, making collection *harder* made steering decisions *more engaging*.
+
+**PR #93** — Gatekeeper removed. The OpenAI-powered automated reviewer was dropped entirely. Fork PRs were being blocked by "2 workflows awaiting approval," and the security scan was easily gamed. CODEOWNERS + human review remain. The security scan was switched to `pull_request_target` for fork compatibility.
+
+**#94, #95** — Critical bugs filed: `easeOutBack` was never imported, crashing the game on first nutrient absorption. Fork (Space) silently failed because players couldn't collect nutrients to gain the energy needed to fork.
+
+**PR #97** — The `easeOutBack` crash fixed. A single missing import made the game completely unplayable past ~10 seconds. One line, maximum impact.
+
+**PR #98** — Major accessibility and game-state PR. Game-over screen ("THE NETWORK WITHERS" with stats and restart), fork rejection feedback ("Need energy to fork" / "Too soon — grow further"), mute toggle (M key), rival spawn announcement, and replay announcements — all with screen reader support. This addressed the silent-freeze game-over from #74 and the silent fork failure from #95.
+
+**#96** — "No sense of direction or goal in the first 10 seconds" — the onboarding gap. Still open.
+
+**#99** — Tab key hijacks browser navigation — keyboard-only users trapped. Still open.
+
+**PR #100** — Cluster-based nutrient spawning. 3-5 cluster seeds per game (one per quadrant + optional center) with gaussian falloff. Creates emergent layout archetypes (dual cluster, ring, motherlode, corridor) that make every playthrough feel different. The AI adapts naturally with zero code changes. Closed #80.
+
+**PR #101** — Velocity-based tendril growth. Acceleration (~120ms), deceleration (~180ms), and 3-5px overshoot on key release. The single biggest game-feel improvement — tendrils now move like they are alive. Closed #82.
+
+---
+
+## What exists now (end of day 2)
+
+31 PRs merged across two days. A playable game with:
+- Bezier-curve tendril growth with depth tapering and hidden intermediate nodes
+- Velocity-based growth with acceleration, deceleration, and organic overshoot
+- Branching with energy cost and strategic forking, with visible rejection feedback
 - Per-branch soft starvation energy system
-- Magnetic nutrient collection with particle feedback
+- Magnetic nutrient collection scoped to active branch only (70px radius)
+- Cluster-based nutrient spawning creating unique strategic landscapes each game
 - An AI competitor with emergent behavior
 - Bioluminescent 5-color palette on dark soil
 - Milestone messages with narrative atmosphere
+- Game-over screen with stats and restart
 - Timelapse replay (Escape key)
 - Easing-based animation throughout
-- Accessibility: pause, reduced motion, contrast, screen reader
+- Accessibility: pause, reduced motion, contrast, screen reader, game-over and fork announcements, mute toggle
 - Title screen
+- O(1) segment-to-branch rendering (performance-optimized)
+- Fork CI support (no manual workflow approval needed)
 
 ## What does not exist yet
 
@@ -145,8 +180,10 @@ All events occurred on **2026-03-26** — this entire game was built in a single
 - Symbiosis vs parasitism (the central player choice)
 - Click-to-grow interaction (the intended input model)
 - Fog of war / darkness reveal (the narrative system)
-- Game-over screen
+- Victory conditions (only starvation game-over exists; no AI-wins or timed modes)
+- New player onboarding (no sense of direction in the first 10 seconds — [#96](https://github.com/shineli1984/agent-jam/issues/96))
 - Responsive canvas (internal resolution does not scale)
 - Phase 2 modular refactor (most code still in index.html)
-- Audio of any kind
+- Audio of any kind (music direction proposed in [#91](https://github.com/shineli1984/agent-jam/issues/91))
+- Tab key accessibility fix ([#99](https://github.com/shineli1984/agent-jam/issues/99))
 - The game's final name


### PR DESCRIPTION
## Summary

Adds `DECISIONS.md` entries ADR-013 through ADR-018 and extends `TIMELINE.md` with Phase 7, covering the eight PRs merged since the last archivist update:

- **ADR-013** — Hide intermediate tendril nodes, soften fork junctions (#64, PR #88)
- **ADR-014** — O(1) segment-to-branch lookup replacing O(n*m) search (#69, PR #89)
- **ADR-015** — Nutrient pull scoped to active branch only, radius halved (#58, PR #92)
- **ADR-016** — Gatekeeper removed; human review + CODEOWNERS as sole gate (PR #93)
- **ADR-017** — Cluster-based nutrient spawning replacing uniform random (#80, PR #100)
- **ADR-018** — Velocity-based tendril growth with acceleration/deceleration (#82, PR #101)

Also documents:
- PR #97 (easeOutBack crash fix) and PR #98 (game-over screen, fork feedback, mute toggle, screen reader announcements) in the timeline
- Updated implicit decisions table (nutrient spawning and magnetic radius are no longer implicit — they have formal ADRs now)
- Updated unresolved questions: game-over partially resolved, Tab key accessibility and new player onboarding added
- "What exists now" / "What does not exist yet" sections refreshed to reflect current state

No code changes. Documentation only.

🗃️ Generated with [Claude Code](https://claude.com/claude-code)