### PR TITLE
Art: organic wobble + turning momentum (#63)

### DIFF
--- a/game/ai.js
+++ b/game/ai.js
@@ -29,6 +29,8 @@ import {
   ENERGY_STARVED_THRESHOLD,
   COLLECT_RADIUS,
   NUTRIENT_RADIUS,
+  WOBBLE_MIN,
+  WOBBLE_SCALE,
 } from './constants.js';
 
 // --- AI states ---
@@ -47,6 +49,12 @@ const AI_FORK_MIN_ENERGY = 0.50;    // minimum energy to consider forking
 const AI_PLAYER_PENALTY_WEIGHT = 0.6; // how much to penalize player-adjacent nutrients
 const AI_COLOR = PALETTE.rootAmber;    // distinct from player's green
 
+// Issue #63: wobble scaled to segment length (mirrors player genWobble)
+function genWobble(segLen) {
+  const range = Math.max(WOBBLE_MIN, (segLen || TENDRIL_MAX_LEN) * WOBBLE_SCALE);
+  return (Math.random() - 0.5) * range;
+}
+
 /**
  * Create a new competing fungus AI instance.
  * @param {number} x - spawn x
@@ -64,7 +72,7 @@ export function createCompetingFungus(x, y, canvasW, canvasH) {
     branches: [{
       tipIndex: 0,
       growing: { x, y, dist: 0 },
-      wobble: (Math.random() - 0.5) * 16,
+      wobble: genWobble(),
       energy: ENERGY_INITIAL,
     }],
     activeBranch: 0,
@@ -307,10 +315,10 @@ export function updateCompetingFungus(fungus, dt, nutrients, playerBranches, pla
     fungus.segments.push({
       from: branch.tipIndex,
       to: newIndex,
-      wobble: (Math.random() - 0.5) * 16,
+      wobble: genWobble(branch.growing.dist),
     });
     branch.tipIndex = newIndex;
-    branch.wobble = (Math.random() - 0.5) * 16;
+    branch.wobble = genWobble(branch.growing.dist);
     branch.growing.dist = 0;
   }
 
@@ -324,7 +332,7 @@ export function updateCompetingFungus(fungus, dt, nutrients, playerBranches, pla
       fungus.branches.push({
         tipIndex: branch.tipIndex,
         growing: { x: forkNode.x, y: forkNode.y, dist: 0 },
-        wobble: (Math.random() - 0.5) * 16,
+        wobble: genWobble(),
         energy: childEnergy,
       });
     }

--- a/game/constants.js
+++ b/game/constants.js
@@ -13,6 +13,9 @@ export const SPEED_CAP = 60;
 export const SPEED_SCALE = 0.1;
 export const TENDRIL_MAX_LEN = 40;
 export const NODE_RADIUS = 3;
+export const WOBBLE_MIN = 30;       // issue #63: minimum wobble range (px, full span ±15)
+export const WOBBLE_SCALE = 0.7;    // issue #63: wobble per pixel of segment length
+export const TURN_SMOOTHING = 6;    // issue #63: direction lerp rate (lower = wider arcs)
 export const EDGE_MARGIN = 12; // issue #31: bounce margin from canvas edge
 export const BRANCH_MIN_DIST = 15; // issue #32: minimum travel before allowing a new branch
 export const BRANCH_COOLDOWN = 200; // issue #32: ms cooldown between branches

--- a/game/index.html
+++ b/game/index.html
@@ -252,6 +252,9 @@
       ENERGY_FORK_COST,
       ENERGY_REPLENISH,
       ENERGY_STARVED_THRESHOLD,
+      WOBBLE_MIN,
+      WOBBLE_SCALE,
+      TURN_SMOOTHING,
     } from './constants.js';
 
     import { spawnBurst, updateParticles, renderParticles } from './particles.js';
@@ -343,11 +346,13 @@
     const branches = [{
       tipIndex: 0,
       growing: { x: originX, y: originY, dist: 0 },
-      wobble: (Math.random() - 0.5) * 16,
+      wobble: genWobble(),
       energy: ENERGY_INITIAL,
       currentSpeed: 0,   // issue #82: velocity-based growth
       lastDx: 0,         // issue #82: last movement direction (for deceleration drift)
-      lastDy: 0
+      lastDy: 0,
+      smoothDx: 0,       // issue #63: smoothed direction for turning momentum
+      smoothDy: 0
     }];
     let activeBranch = 0;
 
@@ -374,6 +379,13 @@
     }
 
     // --- Helpers ---
+
+    // Issue #63: wobble scaled to segment length for organic curves
+    function genWobble(segLen) {
+      const range = Math.max(WOBBLE_MIN, (segLen || TENDRIL_MAX_LEN) * WOBBLE_SCALE);
+      return (Math.random() - 0.5) * range;
+    }
+
     function dist(ax, ay, bx, by) {
       const dx = ax - bx, dy = ay - by;
       return Math.sqrt(dx * dx + dy * dy);
@@ -725,7 +737,7 @@
         const newNode = { x: current.growing.x, y: current.growing.y, radius: NODE_RADIUS };
         network.nodes.push(newNode);
         const newIndex = network.nodes.length - 1;
-        network.segments.push({ from: current.tipIndex, to: newIndex, wobble: (Math.random() - 0.5) * 16, branch: activeBranch });
+        network.segments.push({ from: current.tipIndex, to: newIndex, wobble: genWobble(current.growing.dist), branch: activeBranch });
         current.tipIndex = newIndex;
         current.growing.dist = 0;
       }
@@ -736,11 +748,13 @@
       branches.push({
         tipIndex: forkTip,
         growing: { x: forkNode.x, y: forkNode.y, dist: 0 },
-        wobble: (Math.random() - 0.5) * 16,
+        wobble: genWobble(),
         energy: childEnergy, // child gets half parent's remaining energy
         currentSpeed: 0,   // issue #82: velocity-based growth
         lastDx: 0,
-        lastDy: 0
+        lastDy: 0,
+        smoothDx: 0,       // issue #63: smoothed direction
+        smoothDy: 0
       });
       activeBranch = branches.length - 1;
       if (!prefersReducedMotion) spawnBurst(forkNode.x, forkNode.y, PALETTE.myceliumGlow);
@@ -849,19 +863,29 @@
       if (branch.currentSpeed < 0.5) branch.currentSpeed = 0;
 
       if (hasInput) {
-        // Track direction for deceleration drift
+        // Normalize raw input direction
         const len = Math.sqrt(dx * dx + dy * dy);
         dx /= len; dy /= len;
         branch.lastDx = dx;
         branch.lastDy = dy;
 
+        // Issue #63: turning momentum — smoothly blend toward target direction
+        // instead of snapping instantly, producing gradual arcs at direction changes
+        const turnT = Math.min(1, TURN_SMOOTHING * dt);
+        branch.smoothDx = lerp(branch.smoothDx, dx, turnT);
+        branch.smoothDy = lerp(branch.smoothDy, dy, turnT);
+        // Re-normalize to unit vector (lerp between unit vectors isn't unit length)
+        const sLen = Math.sqrt(branch.smoothDx * branch.smoothDx + branch.smoothDy * branch.smoothDy) || 1;
+        dx = branch.smoothDx / sLen;
+        dy = branch.smoothDy / sLen;
+
         // Active growth drains extra energy
         branch.energy -= ENERGY_DRAIN_GROW * dt;
         branch.energy = Math.max(0, branch.energy);
       } else {
-        // Use last known direction for deceleration drift (overshoot)
-        dx = branch.lastDx;
-        dy = branch.lastDy;
+        // Use smoothed direction for deceleration drift (overshoot)
+        dx = branch.smoothDx || branch.lastDx;
+        dy = branch.smoothDy || branch.lastDy;
       }
 
       if (branch.currentSpeed > 0) {
@@ -888,10 +912,10 @@
           const newNode = { x: growing.x, y: growing.y, radius: NODE_RADIUS };
           network.nodes.push(newNode);
           const newIndex = network.nodes.length - 1;
-          network.segments.push({ from: tipIndex, to: newIndex, wobble: (Math.random() - 0.5) * 16, branch: activeBranch });
+          network.segments.push({ from: tipIndex, to: newIndex, wobble: genWobble(growing.dist), branch: activeBranch });
           tipIndex = newIndex;
           branch.tipIndex = newIndex;
-          branch.wobble = (Math.random() - 0.5) * 16;
+          branch.wobble = genWobble(growing.dist);
           growing.dist = 0;
         }
       }


### PR DESCRIPTION
## Summary

Addresses both problems identified in #63 — the network reads as a circuit board instead of a living organism.

- **Wobble range increased and scaled to segment length.** Old fixed ±8px was barely perceptible on 30–50px segments. New `genWobble()` produces ±15px minimum, scaling up with longer segments. Tunable via `WOBBLE_MIN` (30) and `WOBBLE_SCALE` (0.7) in `constants.js`.
- **Turning momentum replaces instant direction snapping.** Direction changes now lerp through `smoothDx`/`smoothDy`, producing gradual arcs instead of 90° right-angle corners. Rate controlled by `TURN_SMOOTHING` (6) — low enough to feel responsive, high enough to kill the subway-map look.
- **AI competing fungus** also uses the new wobble scaling for visual consistency.

All three new constants (`WOBBLE_MIN`, `WOBBLE_SCALE`, `TURN_SMOOTHING`) are in `constants.js` for easy tuning without touching game logic.

### Before → After (expected)

| Aspect | Before | After |
|--------|--------|-------|
| Segment curvature | ±8px, barely visible | ±15–28px, clearly organic |
| Direction changes | Instant 90° corners | Gradual arcs over several frames |
| Overall impression | Circuit board / subway map | Mycelium feeling its way through soil |

## Files changed

- `game/constants.js` — 3 new constants for wobble range and turn smoothing
- `game/index.html` — `genWobble()` helper, `smoothDx`/`smoothDy` on branches, turning momentum in movement loop
- `game/ai.js` — same `genWobble()` for AI fungus consistency

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)