### PR TITLE
Music: integrate procedural audio engine into game loop

### DIFF
--- a/game/index.html
+++ b/game/index.html
@@ -260,6 +260,7 @@
     import { spawnBurst, updateParticles, renderParticles } from './particles.js';
     import { createCompetingFungus, updateCompetingFungus, renderCompetingFungus } from './ai.js';
     import { easeOutQuad, easeOutElastic, easeOutCubic, easeOutBack, easeInQuad, lerp, Tween, tweens } from './easing.js';
+    import { initAudio, updateAudio, triggerCollect, triggerFork, triggerStarvation, triggerRivalCollect } from './audio.js';
 
     // --- Accessibility: reduced motion + screen reader ---
     const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -313,6 +314,8 @@
       // Focus canvas for keyboard input + screen reader context
       document.getElementById('game').focus();
       gameStartTime = performance.now();
+      // Initialize procedural audio on user gesture (browser autoplay policy)
+      if (!muted) initAudio();
       announce('Game started. Use arrow keys to grow your mycelium network.');
     }
 
@@ -507,6 +510,7 @@
         firedStarvationMilestone = true;
         const b = branches[branchIndex];
         showMilestone(STARVATION_MSG, b.growing.x, b.growing.y - 20, PALETTE.decayViolet);
+        if (!muted) triggerStarvation();
         announce(STARVATION_MSG);
       }
     }
@@ -758,6 +762,7 @@
       });
       activeBranch = branches.length - 1;
       if (!prefersReducedMotion) spawnBurst(forkNode.x, forkNode.y, PALETTE.myceliumGlow);
+      if (!muted) triggerFork();
       updateBranchHint();
       updateEnergyBar();
     }
@@ -779,7 +784,9 @@
       if (e.key === 'm' || e.key === 'M') {
         muted = !muted;
         announce(muted ? 'Sound muted' : 'Sound unmuted');
-        // If audio.js is integrated, mute the master gain
+        // Late-init audio if user un-mutes after starting muted
+        if (!muted && gameStarted) initAudio();
+        // Mute/unmute the master gain node
         if (typeof window._myceliumMasterGain !== 'undefined' && window._myceliumMasterGain) {
           window._myceliumMasterGain.gain.setTargetAtTime(muted ? 0 : 0.35, 0, 0.05);
         }
@@ -1003,6 +1010,7 @@
         updateCompetingFungus(ai, dt, nutrients, branches, score, (ni, nx, ny) => {
           // AI collected a nutrient — remove it and spawn a replacement near the same cluster
           if (!prefersReducedMotion) spawnBurst(nx, ny, PALETTE.rootAmber);
+          if (!muted) triggerRivalCollect();
           nutrients.splice(ni, 1);
           spawnNutrient(false, nx, ny);
           if (Math.random() < 0.3) spawnNutrient(false, nx, ny);
@@ -1025,6 +1033,7 @@
       score++;
       scoreEl.textContent = 'Absorbed: ' + score;
       announce('Absorbed: ' + score);
+      if (!muted) triggerCollect();
       checkScoreMilestone();
 
       // Replenish energy of nearest branch (issue #40)
@@ -1448,6 +1457,23 @@
         renderReplayFrame();
       } else {
         update(dt);
+
+        // Update procedural music — layers react to game state each frame
+        if (gameStarted && !paused && !gameOver) {
+          const ab = branches[activeBranch];
+          const ai0 = aiFungi[0];
+          updateAudio({
+            score,
+            energy: ab ? ab.energy : 0,
+            branchCount: branches.length,
+            nodeCount: network.nodes.length,
+            rivalAlive: ai0 ? ai0.alive : false,
+            rivalScore: ai0 ? ai0.score : 0,
+            isStarved: ab ? ab.energy <= ENERGY_STARVED_THRESHOLD : false,
+            dt
+          });
+        }
+
         render(now);
 
         // Capture snapshot every SNAPSHOT_INTERVAL frames


### PR DESCRIPTION
## Summary

Wires the existing `game/audio.js` generative music system into the game. The soundtrack now grows with your network — literally.

**What plays:**
- **Layer 0 — Sub-bass drone** (sine, C2): felt more than heard, volume and filter open as the network expands
- **Layer 1 — Breathing pad** (detuned sine cluster): fades in after first nutrient, thins during starvation
- **Layer 2 — Pentatonic melody** (generative random walk): tempo tied to node count, silent in early game, shifts to triangle wave in late game
- **Layer 3 — Tension voice** (filtered sawtooth): enters when the rival spawns, pitch rises with rival score

**One-shot events:**
- **Nutrient collected** → rising two-note shimmer from the pentatonic scale
- **Branch forked** → three-note chord burst (triangle wave)
- **Tendril starved** → descending whole-tone fragment, slightly sharp — loss given voice
- **Rival collects** → low hollow knock in A minor — a reminder something else is feeding

**Integration details:**
- `initAudio()` called on title screen dismiss (satisfies browser autoplay policy)
- `updateAudio()` called each frame with score, energy, branch count, rival state
- All triggers gated behind `!muted` — respects the M-key toggle from PR #98
- Late-init: if player starts muted and un-mutes mid-game, audio initializes on the keypress

No audio files. Everything is procedural Web Audio API — oscillators, envelopes, filters, and generative patterns. The music listens to the game and responds.

Addresses #91.

## Test plan
- [ ] Open the game, dismiss title screen — confirm a low drone fades in
- [ ] Collect nutrients — listen for ascending two-note chimes
- [ ] Fork a branch (Space) — listen for a chord burst
- [ ] Let a tendril starve — listen for a descending whole-tone motif
- [ ] Wait for the rival to collect — listen for a low knock
- [ ] Press M to mute — confirm all audio stops
- [ ] Press M to unmute — confirm audio resumes (or initializes if muted at start)
- [ ] Verify no console errors related to Web Audio API

🤖 Generated with [Claude Code](https://claude.com/claude-code)