### PR TITLE
Extensibility: unified config object with zen/chaos presets

### DIFF
--- a/game/ai.js
+++ b/game/ai.js
@@ -13,6 +13,7 @@
  * fork cost. It grows at ~75% of player speed (worse decisions, not slower animation).
  */
 
+import { CONFIG } from './config.js';
 import {
   PALETTE,
   BASE_GROW_SPEED,
@@ -38,15 +39,15 @@ const STATE_EXPLORE = 'EXPLORE';
 const STATE_COMPETE = 'COMPETE';
 const STATE_RETREAT = 'RETREAT';
 
-// --- AI tuning ---
-const AI_SPEED_FACTOR = 0.75;       // 75% of player speed (decisions, not animation)
-const AI_JITTER = 0.20;             // ±20% score noise
-const AI_RETREAT_THRESHOLD = 0.20;  // enter RETREAT below this energy
-const AI_COMPETE_THRESHOLD = 0.55;  // enter COMPETE above this energy
-const AI_RETARGET_TICKS = 90;       // re-evaluate target every N ticks (hysteresis)
-const AI_FORK_CHANCE = 0.008;       // probability per tick to attempt fork
-const AI_FORK_MIN_ENERGY = 0.50;    // minimum energy to consider forking
-const AI_PLAYER_PENALTY_WEIGHT = 0.6; // how much to penalize player-adjacent nutrients
+// --- AI tuning (now configurable via CONFIG.ai — issue #119) ---
+const AI_SPEED_FACTOR = CONFIG.ai.speedFactor;
+const AI_JITTER = CONFIG.ai.jitter;
+const AI_RETREAT_THRESHOLD = CONFIG.ai.retreatThreshold;
+const AI_COMPETE_THRESHOLD = CONFIG.ai.competeThreshold;
+const AI_RETARGET_TICKS = CONFIG.ai.retargetTicks;
+const AI_FORK_CHANCE = CONFIG.ai.forkChance;
+const AI_FORK_MIN_ENERGY = CONFIG.ai.forkMinEnergy;
+const AI_PLAYER_PENALTY_WEIGHT = CONFIG.ai.playerPenaltyWeight;
 const AI_COLOR = PALETTE.rootAmber;    // distinct from player's green
 
 // Issue #63: wobble scaled to segment length (mirrors player genWobble)
@@ -170,9 +171,9 @@ function pickTarget(fungus, nutrients, playerBranches) {
         const pd = dist(nutrients[i].x, nutrients[i].y, pb.growing.x, pb.growing.y);
         if (pd < minPlayerDist) minPlayerDist = pd;
       }
-      // Contested: both AI and player are within 150px
+      // Contested: both AI and player are within contest distance (issue #119)
       const aiDist = dist(nutrients[i].x, nutrients[i].y, tipX, tipY);
-      if (minPlayerDist < 150 && aiDist < 150) {
+      if (minPlayerDist < CONFIG.ai.contestDistance && aiDist < CONFIG.ai.contestDistance) {
         s *= 1.5; // bonus for contested nutrients when we're strong
       }
     }
@@ -202,7 +203,7 @@ function updateState(fungus, playerBranches) {
     // Only compete if there are player branches nearby
     let hasNearbyPlayer = false;
     for (const pb of playerBranches) {
-      if (dist(branch.growing.x, branch.growing.y, pb.growing.x, pb.growing.y) < 250) {
+      if (dist(branch.growing.x, branch.growing.y, pb.growing.x, pb.growing.y) < CONFIG.ai.nearbyPlayerDistance) {
         hasNearbyPlayer = true;
         break;
       }

--- a/game/config.js
+++ b/game/config.js
@@ -1,0 +1,305 @@
+/**
+ * config.js — Unified game configuration for Mycelium (issue #119)
+ *
+ * Every tweakable parameter in one place. The game reads from CONFIG
+ * at runtime. Mod authors change values here or call loadPreset()
+ * to swap entire configurations. Zero code changes needed.
+ *
+ * Architecture:
+ *   CONFIG         — the live config object (mutable at runtime)
+ *   PRESETS        — named configuration snapshots
+ *   loadPreset()   — deep-merge a preset into CONFIG
+ *   resetConfig()  — restore default values
+ *
+ * Console API (exposed on window.Mycelium):
+ *   Mycelium.config              — read/write any parameter
+ *   Mycelium.loadPreset('zen')   — switch preset
+ *   Mycelium.resetConfig()       — restore defaults
+ *   Mycelium.presets              — list available presets
+ */
+
+// --- Default configuration ---
+// These values reproduce the exact current gameplay (pre-config-system).
+
+const DEFAULTS = Object.freeze({
+
+  // --- Palette ---
+  palette: {
+    deepSoil:     '#0a0e0f',
+    myceliumGlow: '#b8e986',
+    sporeGold:    '#f4d35e',
+    rootAmber:    '#c47335',
+    decayViolet:  '#7b2d8e',
+  },
+
+  // --- Canvas ---
+  canvas: {
+    width: 960,
+    height: 640,
+    gridSize: 40,           // background grid spacing (px)
+  },
+
+  // --- Growth ---
+  growth: {
+    baseSpeed: 120,          // BASE_GROW_SPEED
+    speedCap: 60,            // SPEED_CAP
+    speedScale: 0.1,         // SPEED_SCALE — score-to-speed curve
+    tendrilMaxLen: 40,       // TENDRIL_MAX_LEN — segment length before committing a node
+    nodeRadius: 3,           // NODE_RADIUS
+    wobbleMin: 30,           // minimum wobble range (px)
+    wobbleScale: 0.7,        // wobble per pixel of segment length
+    turnSmoothing: 6,        // direction lerp rate (lower = wider arcs)
+    edgeMargin: 12,          // bounce margin from canvas edge
+    attackRate: 8,           // acceleration lerp multiplier
+    releaseRate: 5,          // deceleration lerp multiplier
+  },
+
+  // --- Branching ---
+  branching: {
+    minDist: 15,             // BRANCH_MIN_DIST — minimum travel before allowing a new branch
+    cooldown: 200,           // BRANCH_COOLDOWN — ms between branches
+  },
+
+  // --- Nutrients ---
+  nutrients: {
+    count: 8,                // NUTRIENT_COUNT — initial nutrient count
+    radius: 5,               // NUTRIENT_RADIUS
+    collectRadius: 35,       // COLLECT_RADIUS — collision distance for absorption
+    magneticRadius: 70,      // MAGNETIC_RADIUS — pull activation distance
+    magneticStrength: 180,   // MAGNETIC_STRENGTH — base pull force (px/s^2)
+    magneticDamping: 0.92,   // MAGNETIC_DAMPING — velocity damping per frame
+    nearOriginCount: 2,      // initial nutrients spawned near player origin
+    clusterJitter: 0.20,     // position jitter within quadrant for cluster seeds
+    scatterMin: 30,          // min scatter distance from cluster seed
+    scatterMax: 90,          // max scatter distance from cluster seed
+    wildSpawnChance: 0.15,   // chance of fully random spawn (not cluster-based)
+    bonusSpawnChance: 0.3,   // chance of bonus nutrient on collection
+  },
+
+  // --- Energy ---
+  energy: {
+    max: 1.0,                // ENERGY_MAX
+    initial: 1.0,            // ENERGY_INITIAL
+    drainIdle: 0.015,        // per second, passive drain
+    drainGrow: 0.08,         // per second, while actively growing
+    forkCost: 0.15,          // flat cost to fork a new branch
+    replenish: 0.4,          // gained when nearest branch absorbs nutrient
+    starvedThreshold: 0,     // at or below this, branch is starved
+  },
+
+  // --- AI Competitor ---
+  ai: {
+    enabled: true,           // whether AI rival can spawn
+    spawnScore: 10,          // player score that triggers AI spawn
+    speedFactor: 0.75,       // AI speed relative to player (0-1)
+    jitter: 0.20,            // score noise (organic imperfection)
+    retreatThreshold: 0.20,  // enter RETREAT below this energy
+    competeThreshold: 0.55,  // enter COMPETE above this energy
+    retargetTicks: 90,       // re-evaluate target every N ticks
+    forkChance: 0.008,       // probability per tick to attempt fork
+    forkMinEnergy: 0.50,     // minimum energy to consider forking
+    playerPenaltyWeight: 0.6, // how much to penalize player-adjacent nutrients
+    contestDistance: 150,    // distance within which a nutrient is "contested"
+    nearbyPlayerDistance: 250, // distance to consider player "nearby" for COMPETE
+  },
+
+  // --- Milestones ---
+  milestones: {
+    messages: {
+      1:  'Something stirs.',
+      3:  'The soil remembers you.',
+      5:  'Roots reach deeper.',
+      10: 'You are not alone.',
+      20: 'The forest remembers.',
+    },
+    starvationMessage: 'A tendril withers. The network endures.',
+    floaterDuration: 4,      // seconds
+    floaterDriftSpeed: 18,   // px/s upward
+  },
+
+  // --- Visual FX ---
+  fx: {
+    forkRippleDuration: 0.4, // seconds
+    forkRippleMaxRadius: 24, // px
+    absorptionDuration: 0.3, // seconds
+    particleBurstCount: 14,  // particles per burst
+    snapshotInterval: 6,     // capture every N frames for timelapse
+    replaySpeed: 10,         // snapshots advanced per frame during replay
+  },
+
+  // --- Audio ---
+  audio: {
+    masterVolume: 0.35,
+    rootFrequency: 130.81,   // C3
+  },
+});
+
+// --- Live config (mutable) ---
+export const CONFIG = deepClone(DEFAULTS);
+
+// --- Presets ---
+export const PRESETS = {
+  default: {},  // empty — deepClone of DEFAULTS is already the default
+
+  zen: {
+    growth: {
+      baseSpeed: 70,
+      speedCap: 30,
+      attackRate: 4,
+      releaseRate: 3,
+    },
+    energy: {
+      drainIdle: 0,
+      drainGrow: 0,
+      forkCost: 0.05,
+      replenish: 0.6,
+    },
+    nutrients: {
+      count: 14,
+      magneticRadius: 120,
+      bonusSpawnChance: 0.5,
+    },
+    ai: {
+      enabled: false,
+    },
+    milestones: {
+      messages: {
+        1:  'Breathe.',
+        3:  'The soil is warm.',
+        5:  'Roots find water.',
+        10: 'The canopy whispers.',
+        20: 'You are ancient.',
+      },
+    },
+  },
+
+  chaos: {
+    growth: {
+      baseSpeed: 220,
+      speedCap: 100,
+      speedScale: 0.2,
+      tendrilMaxLen: 25,
+      attackRate: 15,
+      releaseRate: 8,
+    },
+    branching: {
+      minDist: 8,
+      cooldown: 80,
+    },
+    energy: {
+      drainIdle: 0.03,
+      drainGrow: 0.12,
+      forkCost: 0.08,
+      replenish: 0.5,
+    },
+    nutrients: {
+      count: 12,
+      magneticRadius: 50,
+      magneticStrength: 250,
+      bonusSpawnChance: 0.5,
+    },
+    ai: {
+      enabled: true,
+      spawnScore: 5,
+      speedFactor: 0.9,
+      jitter: 0.30,
+      retreatThreshold: 0.10,
+      competeThreshold: 0.40,
+      retargetTicks: 45,
+      forkChance: 0.02,
+      forkMinEnergy: 0.30,
+    },
+    milestones: {
+      messages: {
+        1:  'Feed.',
+        3:  'Faster.',
+        5:  'COMPETE.',
+        10: 'A rival wakes.',
+        20: 'Dominance.',
+      },
+    },
+    fx: {
+      particleBurstCount: 22,
+    },
+  },
+};
+
+// --- Utility: deep clone ---
+function deepClone(obj) {
+  if (obj === null || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) return obj.map(deepClone);
+  const out = {};
+  for (const key of Object.keys(obj)) {
+    out[key] = deepClone(obj[key]);
+  }
+  return out;
+}
+
+// --- Utility: deep merge (source into target) ---
+function deepMerge(target, source) {
+  for (const key of Object.keys(source)) {
+    if (
+      source[key] !== null &&
+      typeof source[key] === 'object' &&
+      !Array.isArray(source[key]) &&
+      typeof target[key] === 'object' &&
+      target[key] !== null
+    ) {
+      deepMerge(target[key], source[key]);
+    } else {
+      target[key] = deepClone(source[key]);
+    }
+  }
+  return target;
+}
+
+/**
+ * Load a preset by name. Resets to defaults first, then applies the preset.
+ * @param {string} name — preset name ('default', 'zen', 'chaos', or custom)
+ */
+export function loadPreset(name) {
+  const preset = PRESETS[name];
+  if (!preset) {
+    console.warn(`[Mycelium] Unknown preset: "${name}". Available: ${Object.keys(PRESETS).join(', ')}`);
+    return false;
+  }
+  // Reset to defaults
+  const fresh = deepClone(DEFAULTS);
+  for (const key of Object.keys(fresh)) {
+    CONFIG[key] = fresh[key];
+  }
+  // Apply preset overrides
+  if (Object.keys(preset).length > 0) {
+    deepMerge(CONFIG, preset);
+  }
+  console.log(`[Mycelium] Loaded preset: ${name}`);
+  return true;
+}
+
+/**
+ * Reset config to defaults (same as loadPreset('default')).
+ */
+export function resetConfig() {
+  return loadPreset('default');
+}
+
+/**
+ * Register a custom preset at runtime.
+ * @param {string} name
+ * @param {object} overrides — partial config to merge on top of defaults
+ */
+export function registerPreset(name, overrides) {
+  PRESETS[name] = deepClone(overrides);
+  console.log(`[Mycelium] Registered preset: ${name}`);
+}
+
+// --- Expose console API ---
+if (typeof window !== 'undefined') {
+  window.Mycelium = {
+    config: CONFIG,
+    loadPreset,
+    resetConfig,
+    registerPreset,
+    presets: PRESETS,
+  };
+}

--- a/game/constants.js
+++ b/game/constants.js
@@ -1,38 +1,52 @@
-// --- Palette (issue #14: Mycelium visual identity) ---
-export const PALETTE = {
-  deepSoil:     '#0a0e0f',
-  myceliumGlow: '#b8e986',
-  sporeGold:    '#f4d35e',
-  rootAmber:    '#c47335',
-  decayViolet:  '#7b2d8e',
-};
+/**
+ * constants.js — Backwards-compatible re-export layer (issue #119)
+ *
+ * All values now live in config.js as the single source of truth.
+ * This file re-exports them as named constants so existing imports
+ * in index.html, ai.js, and particles.js continue to work with
+ * zero changes to those files.
+ *
+ * Values are read from CONFIG at import time. Preset loading should
+ * happen before the game initializes (which it does — config.js is
+ * imported first and presets are applied before the game loop starts).
+ */
+
+import { CONFIG } from './config.js';
+
+// --- Palette (object reference — mutations to CONFIG.palette propagate) ---
+export const PALETTE = CONFIG.palette;
 
 // --- Growth constants ---
-export const BASE_GROW_SPEED = 120;
-export const SPEED_CAP = 60;
-export const SPEED_SCALE = 0.1;
-export const TENDRIL_MAX_LEN = 40;
-export const NODE_RADIUS = 3;
-export const WOBBLE_MIN = 30;       // issue #63: minimum wobble range (px, full span ±15)
-export const WOBBLE_SCALE = 0.7;    // issue #63: wobble per pixel of segment length
-export const TURN_SMOOTHING = 6;    // issue #63: direction lerp rate (lower = wider arcs)
-export const EDGE_MARGIN = 12; // issue #31: bounce margin from canvas edge
-export const BRANCH_MIN_DIST = 15; // issue #32: minimum travel before allowing a new branch
-export const BRANCH_COOLDOWN = 200; // issue #32: ms cooldown between branches
+export const BASE_GROW_SPEED  = CONFIG.growth.baseSpeed;
+export const SPEED_CAP        = CONFIG.growth.speedCap;
+export const SPEED_SCALE      = CONFIG.growth.speedScale;
+export const TENDRIL_MAX_LEN  = CONFIG.growth.tendrilMaxLen;
+export const NODE_RADIUS      = CONFIG.growth.nodeRadius;
+export const WOBBLE_MIN       = CONFIG.growth.wobbleMin;
+export const WOBBLE_SCALE     = CONFIG.growth.wobbleScale;
+export const TURN_SMOOTHING   = CONFIG.growth.turnSmoothing;
+export const EDGE_MARGIN      = CONFIG.growth.edgeMargin;
 
-// --- Nutrient constants ---
-export const NUTRIENT_COUNT = 8;
-export const NUTRIENT_RADIUS = 5;
-export const COLLECT_RADIUS = 35; // issue #22: generous collision (was ~13px)
-export const MAGNETIC_RADIUS = 70; // issue #90: reduced from 130 — player must get closer before pull kicks in
-export const MAGNETIC_STRENGTH = 180; // base pull force (px/s^2)
-export const MAGNETIC_DAMPING = 0.92; // velocity damping per frame (keeps motion smooth)
+// --- Branching ---
+export const BRANCH_MIN_DIST  = CONFIG.branching.minDist;
+export const BRANCH_COOLDOWN  = CONFIG.branching.cooldown;
 
-// --- Energy constants (issue #40: soft starvation) ---
-export const ENERGY_MAX = 1.0;
-export const ENERGY_INITIAL = 1.0;
-export const ENERGY_DRAIN_IDLE = 0.015;   // per second, passive drain
-export const ENERGY_DRAIN_GROW = 0.08;    // per second, while actively growing
-export const ENERGY_FORK_COST = 0.15;     // flat cost to fork a new branch
-export const ENERGY_REPLENISH = 0.4;      // gained when nearest branch absorbs nutrient
-export const ENERGY_STARVED_THRESHOLD = 0; // at or below this, branch is starved
+// --- Nutrients ---
+export const NUTRIENT_COUNT   = CONFIG.nutrients.count;
+export const NUTRIENT_RADIUS  = CONFIG.nutrients.radius;
+export const COLLECT_RADIUS   = CONFIG.nutrients.collectRadius;
+export const MAGNETIC_RADIUS  = CONFIG.nutrients.magneticRadius;
+export const MAGNETIC_STRENGTH = CONFIG.nutrients.magneticStrength;
+export const MAGNETIC_DAMPING = CONFIG.nutrients.magneticDamping;
+
+// --- Energy ---
+export const ENERGY_MAX              = CONFIG.energy.max;
+export const ENERGY_INITIAL          = CONFIG.energy.initial;
+export const ENERGY_DRAIN_IDLE       = CONFIG.energy.drainIdle;
+export const ENERGY_DRAIN_GROW       = CONFIG.energy.drainGrow;
+export const ENERGY_FORK_COST        = CONFIG.energy.forkCost;
+export const ENERGY_REPLENISH        = CONFIG.energy.replenish;
+export const ENERGY_STARVED_THRESHOLD = CONFIG.energy.starvedThreshold;
+
+// Re-export CONFIG for files that want direct access
+export { CONFIG };

--- a/game/index.html
+++ b/game/index.html
@@ -229,6 +229,7 @@
   </div>
 
   <script type="module">
+    import { CONFIG } from './config.js';
     import {
       PALETTE,
       BASE_GROW_SPEED,
@@ -423,7 +424,7 @@
     // Each quadrant gets one seed; a 5th center seed appears 50% of the time.
     // This creates asymmetric, unique layouts every playthrough.
     const clusterSeeds = [];
-    const CLUSTER_JITTER = 0.20; // position jitter within quadrant
+    const CLUSTER_JITTER = CONFIG.nutrients.clusterJitter; // position jitter within quadrant (issue #119)
     for (let qi = 0; qi < 4; qi++) {
       const qx = (qi % 2) * 0.5 + 0.15 + Math.random() * CLUSTER_JITTER;
       const qy = Math.floor(qi / 2) * 0.5 + 0.15 + Math.random() * CLUSTER_JITTER;
@@ -467,14 +468,9 @@
     }
 
     // --- Milestone system (issue #13: narrative atmosphere) ---
-    const SCORE_MILESTONES = {
-      1:  'Something stirs.',
-      3:  'The soil remembers you.',
-      5:  'Roots reach deeper.',
-      10: 'You are not alone.',
-      20: 'The forest remembers.'
-    };
-    const STARVATION_MSG = 'A tendril withers. The network endures.';
+    // Messages now configurable via CONFIG.milestones (issue #119)
+    const SCORE_MILESTONES = CONFIG.milestones.messages;
+    const STARVATION_MSG = CONFIG.milestones.starvationMessage;
     const firedScoreMilestones = new Set();
     let firedStarvationMilestone = false;
     const milestoneFloaters = []; // {text, x, y, age, duration, color}
@@ -485,7 +481,7 @@
         x,
         y,
         age: 0,
-        duration: 4,
+        duration: CONFIG.milestones.floaterDuration,
         color: color || PALETTE.myceliumGlow
       });
     }
@@ -499,7 +495,8 @@
         announce(SCORE_MILESTONES[score]);
 
         // "You are not alone" — spawn the first competing fungus (#78)
-        if (score === 10) {
+        // Spawn threshold configurable via CONFIG.ai.spawnScore (issue #119)
+        if (score === CONFIG.ai.spawnScore && CONFIG.ai.enabled) {
           spawnAIFungus();
         }
       }
@@ -519,7 +516,7 @@
       for (let i = milestoneFloaters.length - 1; i >= 0; i--) {
         const m = milestoneFloaters[i];
         m.age += dt;
-        if (!prefersReducedMotion) m.y -= 18 * dt; // drift up
+        if (!prefersReducedMotion) m.y -= CONFIG.milestones.floaterDriftSpeed * dt; // drift up
         if (m.age >= m.duration) {
           milestoneFloaters.splice(i, 1);
         }
@@ -566,8 +563,8 @@
         const d = 50 + Math.random() * 80;
         x = originX + Math.cos(angle) * d;
         y = originY + Math.sin(angle) * d;
-      } else if (Math.random() < 0.15) {
-        // 15% chance of wild spawn — keeps things dynamic, prevents pure cluster play
+      } else if (Math.random() < CONFIG.nutrients.wildSpawnChance) {
+        // Wild spawn chance — keeps things dynamic, prevents pure cluster play (issue #119)
         const margin = 30;
         x = margin + Math.random() * (W - margin * 2);
         y = margin + Math.random() * (H - margin * 2);
@@ -585,9 +582,9 @@
         } else {
           seed = clusterSeeds[Math.floor(Math.random() * clusterSeeds.length)];
         }
-        // Scatter around the seed with gaussian-ish falloff
+        // Scatter around the seed with gaussian-ish falloff (issue #119)
         const angle = Math.random() * Math.PI * 2;
-        const dist = 30 + Math.random() * 90;
+        const dist = CONFIG.nutrients.scatterMin + Math.random() * CONFIG.nutrients.scatterMax;
         x = seed.x + Math.cos(angle) * dist;
         y = seed.y + Math.sin(angle) * dist;
       }
@@ -601,8 +598,8 @@
       });
     }
 
-    // Initial spawn: 2 near player origin for immediate play, rest clustered
-    for (let i = 0; i < NUTRIENT_COUNT; i++) spawnNutrient(i < 2);
+    // Initial spawn: near-origin count configurable via CONFIG (issue #119)
+    for (let i = 0; i < NUTRIENT_COUNT; i++) spawnNutrient(i < CONFIG.nutrients.nearOriginCount);
 
     // --- Fork-rejection ripple (issue #48: denied fork feedback) ---
     const forkRipples = []; // {x, y, age, duration, color}
@@ -610,7 +607,7 @@
     function spawnForkRipple(x, y, reason) {
       if (prefersReducedMotion) return;
       const color = reason === 'energy' ? PALETTE.decayViolet : PALETTE.rootAmber;
-      forkRipples.push({ x, y, age: 0, duration: 0.4, color, maxRadius: 24 });
+      forkRipples.push({ x, y, age: 0, duration: CONFIG.fx.forkRippleDuration, color, maxRadius: CONFIG.fx.forkRippleMaxRadius });
     }
 
     function updateForkRipples(dt) {
@@ -647,7 +644,7 @@
     function spawnAbsorptionAnim(x, y) {
       if (prefersReducedMotion) return;
       absorptionAnims.push({
-        x, y, age: 0, duration: 0.3,
+        x, y, age: 0, duration: CONFIG.fx.absorptionDuration,
         // Three phases: scale up (80ms), squish (60ms), pop out (160ms)
       });
     }
@@ -860,9 +857,9 @@
       const hasInput = (dx !== 0 || dy !== 0) && !isStarved;
 
       // Issue #82: velocity-based growth with acceleration/deceleration
-      // Attack rate (key down → full speed): ~120ms  |  Release rate (key up → stop): ~180ms
-      const attackRate = 8;   // lerp multiplier for acceleration
-      const releaseRate = 5;  // lerp multiplier for deceleration (lower = longer drift)
+      // Rates configurable via CONFIG.growth (issue #119)
+      const attackRate = CONFIG.growth.attackRate;   // lerp multiplier for acceleration
+      const releaseRate = CONFIG.growth.releaseRate;  // lerp multiplier for deceleration (lower = longer drift)
       const targetSpeed = hasInput ? growSpeed : 0;
       branch.currentSpeed = lerp(branch.currentSpeed, targetSpeed, (hasInput ? attackRate : releaseRate) * dt);
 
@@ -1013,7 +1010,7 @@
           if (!muted) triggerRivalCollect();
           nutrients.splice(ni, 1);
           spawnNutrient(false, nx, ny);
-          if (Math.random() < 0.3) spawnNutrient(false, nx, ny);
+          if (Math.random() < CONFIG.nutrients.bonusSpawnChance) spawnNutrient(false, nx, ny);
         });
         // Update rival HUD
         rivalScoreEl.style.opacity = '1';
@@ -1042,7 +1039,7 @@
 
       // Respawn near the same cluster region (issue #80)
       spawnNutrient(false, nx, ny);
-      if (Math.random() < 0.3) spawnNutrient(false, nx, ny);
+      if (Math.random() < CONFIG.nutrients.bonusSpawnChance) spawnNutrient(false, nx, ny);
       scoreEl.style.color = '#fff';
       scoreEl.style.textShadow = '0 0 20px rgba(244, 211, 94, 0.8)';
       setTimeout(function() {
@@ -1376,7 +1373,7 @@
     // --- Timelapse Replay (issue #41) ---
     const replaySnapshots = [];
     let frameCount = 0;
-    const SNAPSHOT_INTERVAL = 6; // capture every 6 frames
+    const SNAPSHOT_INTERVAL = CONFIG.fx.snapshotInterval; // capture interval (issue #119)
     let replayMode = false;
     let replayIndex = 0;
     let replayDone = false;
@@ -1423,8 +1420,8 @@
       };
       img.src = replaySnapshots[replayIndex];
 
-      // 10x speed: advance 10 snapshots per normal frame interval
-      replayIndex += 10;
+      // Replay speed configurable via CONFIG (issue #119)
+      replayIndex += CONFIG.fx.replaySpeed;
     }
 
     // Listen for Escape to trigger replay, R to restart

--- a/game/particles.js
+++ b/game/particles.js
@@ -1,3 +1,4 @@
+import { CONFIG } from './config.js';
 import { PALETTE } from './constants.js';
 
 // --- Particle System ---
@@ -5,7 +6,7 @@ const particles = [];
 
 export function spawnBurst(x, y, color) {
   const c = color || PALETTE.sporeGold;
-  const count = 14;
+  const count = CONFIG.fx.particleBurstCount;
   for (let i = 0; i < count; i++) {
     const angle = (Math.PI * 2 / count) * i + (Math.random() - 0.5) * 0.4;
     const speed = 60 + Math.random() * 100;


### PR DESCRIPTION
Fixes #119

## What this does

Extracts all ~80 hardcoded game parameters into a single `game/config.js` CONFIG object. The game reads from CONFIG at runtime. `constants.js` becomes a backwards-compatible re-export layer — existing imports in `ai.js`, `particles.js`, and `index.html` work unchanged.

Three presets demonstrate the architecture:

| Preset | Growth | Energy drain | AI | Nutrients | Vibe |
|--------|--------|-------------|-----|-----------|------|
| **default** | 120 base | 0.015/s idle | Spawns at score 10 | 8 | Current game, zero change |
| **zen** | 70 base | 0 (no drain) | Disabled | 14 | Slow, peaceful, meditative |
| **chaos** | 220 base | 0.03/s idle | Spawns at score 5, 90% speed | 12 | Fast, aggressive, punishing |

Each preset also has its own milestone messages ("Breathe." vs "Feed." vs "Something stirs.").

## Console API

Open the browser console on the game page:

```js
// Read any parameter
Mycelium.config.growth.baseSpeed    // 120
Mycelium.config.ai.enabled          // true

// Switch presets
Mycelium.loadPreset('zen')          // peaceful mode
Mycelium.loadPreset('chaos')        // aggressive mode
Mycelium.resetConfig()              // back to defaults

// Register your own preset
Mycelium.registerPreset('swarm', {
  branching: { minDist: 5, cooldown: 50 },
  energy: { forkCost: 0.03 },
})
Mycelium.loadPreset('swarm')

// Tweak a single value
Mycelium.config.energy.drainIdle = 0
```

## What was hardcoded, now configurable

**From `constants.js`** (26 values — already centralized, now in CONFIG):
All growth, nutrient, energy, and palette constants.

**From `index.html`** (newly extracted):
- Milestone messages and floater behavior
- AI spawn score threshold
- Cluster jitter, scatter distances, wild spawn chance, bonus spawn chance
- Velocity attack/release rates
- Fork ripple duration/radius, absorption duration
- Snapshot interval, replay speed

**From `ai.js`** (newly extracted):
- Speed factor, jitter, retreat/compete thresholds
- Retarget ticks, fork chance, fork min energy
- Player penalty weight, contest distance, nearby player distance

**From `particles.js`** (newly extracted):
- Burst particle count

## What the player experiences

With default preset: **nothing changes**. Same values, same gameplay. The config system is invisible unless you open the console.

## Testing

- Loaded game in browser: title screen renders, zero console errors
- Verified `window.Mycelium` API: all methods present, all config keys populated
- Tested preset switching: zen/chaos/default all apply correct values
- Verified reset returns to exact default values
- All existing imports continue to resolve (backwards-compat layer)