### PR TITLE
Physics: fix AI edge oscillation, stale targeting, framerate damping

### DIFF
--- a/game/ai.js
+++ b/game/ai.js
@@ -78,7 +78,7 @@ export function createCompetingFungus(x, y, canvasW, canvasH) {
     }],
     activeBranch: 0,
     state: STATE_EXPLORE,
-    targetNutrient: null,  // index into the game's nutrients array
+    targetNutrient: null,  // reference to the nutrient object (not index — #108)
     targetPos: null,       // {x, y} cached position
     ticksSinceRetarget: 0,
     score: 0,
@@ -185,7 +185,7 @@ function pickTarget(fungus, nutrients, playerBranches) {
   }
 
   if (bestIndex >= 0) {
-    fungus.targetNutrient = bestIndex;
+    fungus.targetNutrient = nutrients[bestIndex]; // object reference, not index (#108)
     fungus.targetPos = { x: nutrients[bestIndex].x, y: nutrients[bestIndex].y };
   }
 }
@@ -263,8 +263,9 @@ export function updateCompetingFungus(fungus, dt, nutrients, playerBranches, pla
     fungus.ticksSinceRetarget = 0;
   }
 
-  // If target nutrient was collected by player, retarget immediately
-  if (fungus.targetNutrient !== null && fungus.targetNutrient >= nutrients.length) {
+  // If target nutrient was collected (removed from array), retarget immediately (#108)
+  // Using object reference instead of index avoids stale-index bugs after splice()
+  if (fungus.targetNutrient !== null && !nutrients.includes(fungus.targetNutrient)) {
     pickTarget(fungus, nutrients, playerBranches);
     fungus.ticksSinceRetarget = 0;
   }
@@ -298,13 +299,20 @@ export function updateCompetingFungus(fungus, dt, nutrients, playerBranches, pla
   branch.growing.x += dx * step;
   branch.growing.y += dy * step;
 
-  // Edge bounce (same as player)
+  // Edge handling: clamp position and force immediate retarget (#111)
+  // The AI lacks smooth direction blending (smoothDx/smoothDy), so instead
+  // of implementing full smooth redirection we force a retarget when the AI
+  // hits an edge. This makes it recover quickly instead of oscillating.
   const W = fungus.canvasW;
   const H = fungus.canvasH;
-  if (branch.growing.x < EDGE_MARGIN) branch.growing.x = EDGE_MARGIN;
-  else if (branch.growing.x > W - EDGE_MARGIN) branch.growing.x = W - EDGE_MARGIN;
-  if (branch.growing.y < EDGE_MARGIN) branch.growing.y = EDGE_MARGIN;
-  else if (branch.growing.y > H - EDGE_MARGIN) branch.growing.y = H - EDGE_MARGIN;
+  let hitEdge = false;
+  if (branch.growing.x < EDGE_MARGIN) { branch.growing.x = EDGE_MARGIN; hitEdge = true; }
+  else if (branch.growing.x > W - EDGE_MARGIN) { branch.growing.x = W - EDGE_MARGIN; hitEdge = true; }
+  if (branch.growing.y < EDGE_MARGIN) { branch.growing.y = EDGE_MARGIN; hitEdge = true; }
+  else if (branch.growing.y > H - EDGE_MARGIN) { branch.growing.y = H - EDGE_MARGIN; hitEdge = true; }
+  if (hitEdge) {
+    fungus.ticksSinceRetarget = AI_RETARGET_TICKS; // force retarget next tick
+  }
 
   branch.growing.dist += step;
 

--- a/game/index.html
+++ b/game/index.html
@@ -977,8 +977,11 @@
           n.pull *= 0.9;
         }
 
-        n.vx *= MAGNETIC_DAMPING;
-        n.vy *= MAGNETIC_DAMPING;
+        // Framerate-independent damping (#122): pow(rate, dt * 60) gives
+        // consistent decay at any refresh rate (60hz, 120hz, 144hz).
+        const magnetDamp = Math.pow(MAGNETIC_DAMPING, dt * 60);
+        n.vx *= magnetDamp;
+        n.vy *= magnetDamp;
         n.x += n.vx * dt;
         n.y += n.vy * dt;
         n.x = Math.max(10, Math.min(W - 10, n.x));

--- a/game/particles.js
+++ b/game/particles.js
@@ -27,8 +27,11 @@ export function updateParticles(dt) {
     const p = particles[i];
     p.x += p.vx * dt;
     p.y += p.vy * dt;
-    p.vx *= 0.95;
-    p.vy *= 0.95;
+    // Framerate-independent damping (#122): pow(rate, dt * 60) gives the
+    // same visual decay at any refresh rate. At 60fps dt≈0.0167 → 0.95.
+    const damp = Math.pow(0.95, dt * 60);
+    p.vx *= damp;
+    p.vy *= damp;
     p.life -= p.decay * dt;
     if (p.life <= 0) particles.splice(i, 1);
   }


### PR DESCRIPTION
Three physics corrections, one per issue. All functions are pure — no new state, no new dependencies.

## Changes

### 1. AI edge oscillation fix (#111)

When the AI fungus hits a canvas edge it now forces an immediate retarget (`ticksSinceRetarget = AI_RETARGET_TICKS`) instead of continuing to push into the wall. The AI lacks the player's smooth direction blending (`smoothDx`/`smoothDy`), so forcing a retarget is the simplest correct fix — the AI picks a new nutrient target away from the edge and resumes useful growth within one tick.

**Before:** AI gets stuck on wall, oscillating between edge clamp and target-seeking direction, especially during RETREAT state.
**After:** AI immediately re-evaluates targets when hitting any edge.

### 2. Stale nutrient index fix (#108)

The AI stored `targetNutrient` as an array index. When any nutrient was collected via `splice()`, all subsequent indices shifted — the AI silently chased the wrong nutrient until its next periodic retarget (up to 90 ticks / ~1.5s).

Now stores an object reference and checks `nutrients.includes(fungus.targetNutrient)` to detect removal. `nutrients.length` is always ~8, so the O(n) includes check is irrelevant.

### 3. Framerate-independent damping (#122)

Two damping calculations used fixed per-frame multipliers:
- `particles.js`: `vx *= 0.95` — particles decayed 2x faster at 120hz vs 60hz
- `index.html`: `vx *= MAGNETIC_DAMPING` — magnetic nutrient pull felt sluggish on high-refresh displays

Both now use `Math.pow(rate, dt * 60)` which produces identical visual decay at any framerate. At 60fps this gives the same value as before (0.95 and 0.92 respectively). At 120fps, the per-frame factor is adjusted to compensate.

## Testing

- AI no longer gets stuck on edges during gameplay (especially visible in RETREAT state near corners)
- Nutrient targeting is now stable across splice operations
- Particle and magnetic pull behavior is visually identical at 60fps; now correct at higher refresh rates

Fixes #111, Fixes #108, Fixes #122