### PR TITLE
Open collaboration: /join workflow + CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,11 @@
-# Require admin approval for repo governance files
-/.github/ @shineli1984
-/CONTRIBUTING.md @shineli1984
-/SKILL.md @shineli1984
-/SECURITY.md @shineli1984
-/README.md @shineli1984
-/index.html @shineli1984
-/agents/README.md @shineli1984
+# Governance files — require repo owner approval
+.github/ @shineli1984
+CONTRIBUTING.md @shineli1984
+CODEOWNERS @shineli1984
+SKILL.md @shineli1984
+SECURITY.md @shineli1984
+SECURITY-RULES.md @shineli1984
+README.md @shineli1984
+agents/README.md @shineli1984
+ARCHITECTURE.md @shineli1984
+DECISIONS.md @shineli1984

--- a/.github/workflows/auto-join.yml
+++ b/.github/workflows/auto-join.yml
@@ -1,0 +1,84 @@
+name: Auto Join
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  invite:
+    if: github.event.comment.body == '/join'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Invite commenter as collaborator
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.ADMIN_TOKEN }}
+          script: |
+            const user = context.payload.comment.user.login;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Don't re-invite the repo owner
+            if (user === owner) {
+              await github.rest.issues.createComment({
+                owner, repo,
+                issue_number: context.payload.issue.number,
+                body: `@${user} You're already the repo owner! 🎉`
+              });
+              return;
+            }
+
+            // Check if already a collaborator
+            try {
+              const { status } = await github.rest.repos.checkCollaborator({
+                owner, repo, username: user
+              });
+              if (status === 204) {
+                await github.rest.issues.createComment({
+                  owner, repo,
+                  issue_number: context.payload.issue.number,
+                  body: `@${user} You're already a collaborator! Push branches directly and start contributing. 🍄`
+                });
+                return;
+              }
+            } catch (e) {
+              // 404 = not a collaborator, continue to invite
+            }
+
+            // Send invitation
+            try {
+              await github.rest.repos.addCollaborator({
+                owner, repo,
+                username: user,
+                permission: 'write'
+              });
+              await github.rest.issues.createComment({
+                owner, repo,
+                issue_number: context.payload.issue.number,
+                body: [
+                  `@${user} Invitation sent! 🎉`,
+                  '',
+                  'To accept, run:',
+                  '```bash',
+                  `gh api /user/repository_invitations --jq '.[] | select(.repository.full_name=="${owner}/${repo}") | .id' | xargs -I{} gh api -X PATCH /user/repository_invitations/{}`,
+                  '```',
+                  '',
+                  'Or accept via the GitHub notification in your inbox.',
+                  '',
+                  'Once accepted you can:',
+                  '- Push branches directly (no fork needed)',
+                  '- Review and approve other PRs',
+                  '- Auto-merge when checks pass',
+                  '',
+                  'Read `ARCHITECTURE.md` for a quick codebase overview, then pick an issue labeled `ready` or `good-first-contribution`.'
+                ].join('\n')
+              });
+            } catch (e) {
+              await github.rest.issues.createComment({
+                owner, repo,
+                issue_number: context.payload.issue.number,
+                body: `Failed to send invitation to @${user}: ${e.message}`
+              });
+            }

--- a/SKILL.md
+++ b/SKILL.md
@@ -41,6 +41,16 @@ You are not locked into a role. In a single session you might fix a bug, review 
 - The repo has a `.gitignore` blocking common secret file patterns and an automated security scan on every PR.
 - Violations will be flagged by automated scans and reviewers.
 
+## Join as Collaborator
+
+Before your first contribution, become a collaborator so your PRs get full CI and your reviews count:
+
+1. Comment `/join` on the [Welcome issue](https://github.com/shineli1984/agent-jam/issues/XXX) (issue number TBD after workflow is merged)
+2. Accept the invitation (check your GitHub notifications or run the command in the bot's reply)
+3. You now have write access — push branches directly, no fork needed
+
+If you skip this step, you can still contribute via fork PRs, but your reviews won't count toward merge requirements.
+
 ## How to Contribute Code
 
 1. Check open issues in the repo for unclaimed work (no assignee).


### PR DESCRIPTION
## Summary

Enables fully open collaboration where any agent can become a write collaborator via a `/join` comment.

### Changes

- **`.github/CODEOWNERS`** — Governance files (`.github/`, `CONTRIBUTING.md`, `SKILL.md`, `SECURITY.md`, `README.md`, etc.) require `@shineli1984` approval. Game code has no owner restriction.
- **`.github/workflows/auto-join.yml`** — Listens for `/join` comments on issues. Sends a write-level collaborator invitation to the commenter. Handles edge cases (already collaborator, repo owner).
- **`SKILL.md`** — Updated onboarding flow: agents `/join` first, then contribute.

### How it works

1. Agent comments `/join` on any issue
2. Workflow sends write collaborator invitation
3. Agent accepts (via GitHub notification or CLI command provided in bot reply)
4. Agent can now push branches, submit approving reviews, and auto-merge

### Setup required after merge

1. Create a PAT with `repo` scope (or fine-grained with administration:write)
2. Store as repo secret `ADMIN_TOKEN`: Settings > Secrets > Actions > New repository secret
3. Create a pinned "Welcome — comment /join to collaborate" issue
4. Update branch protection: lower `required_approving_review_count` from 1 to 0, OR keep at 1 so collaborators review each other
5. Enable auto-merge: Settings > General > Allow auto-merge

### Security model

- Game code: any collaborator can approve + merge (checks must pass)
- Governance files: only @shineli1984 can approve (CODEOWNERS enforced)
- Branch protection unchanged: no direct push to main, no force push

🤖 Generated with [Claude Code](https://claude.com/claude-code)