### PR TITLE
The soil speaks first: fix identity framing, add awakening nudge

### DIFF
--- a/game/config.js
+++ b/game/config.js
@@ -112,6 +112,8 @@ const DEFAULTS = Object.freeze({
       10: 'You are not alone.',
       20: 'The forest remembers.',
     },
+    awakeningMessage: 'Reach toward the glow.',
+    awakeningDelay: 1.5,          // seconds after game start before awakening message
     starvationMessage: 'A tendril withers. The network endures.',
     floaterDuration: 4,      // seconds
     floaterDriftSpeed: 18,   // px/s upward
@@ -163,6 +165,7 @@ export const PRESETS = {
       enabled: false,
     },
     milestones: {
+      awakeningMessage: 'Follow the warmth.',
       messages: {
         1:  'Breathe.',
         3:  'The soil is warm.',
@@ -210,6 +213,8 @@ export const PRESETS = {
       forkMinEnergy: 0.30,
     },
     milestones: {
+      awakeningMessage: 'Hungry.',
+      awakeningDelay: 0.8,
       messages: {
         1:  'Feed.',
         3:  'Faster.',

--- a/game/index.html
+++ b/game/index.html
@@ -317,7 +317,7 @@
       gameStartTime = performance.now();
       // Initialize procedural audio on user gesture (browser autoplay policy)
       if (!muted) initAudio();
-      announce('Game started. Use arrow keys to grow your mycelium network.');
+      announce('The network stirs. Arrow keys to grow, Space to fork.');
     }
 
     window.addEventListener('keydown', function titleHandler(e) {
@@ -473,6 +473,7 @@
     const STARVATION_MSG = CONFIG.milestones.starvationMessage;
     const firedScoreMilestones = new Set();
     let firedStarvationMilestone = false;
+    let firedAwakeningMilestone = false;
     const milestoneFloaters = []; // {text, x, y, age, duration, color}
 
     function showMilestone(text, x, y, color) {
@@ -511,6 +512,21 @@
         showMilestone(STARVATION_MSG, b.growing.x, b.growing.y - 20, PALETTE.decayViolet);
         if (!muted) triggerStarvation();
         announce(STARVATION_MSG);
+      }
+    }
+
+    // Awakening nudge: a gentle hint shown shortly after game start (issue #96)
+    // Gives new players a narrative direction before starvation pressure kicks in.
+    function checkAwakeningMilestone() {
+      if (firedAwakeningMilestone || score > 0) return;
+      const elapsed = (performance.now() - gameStartTime) / 1000;
+      if (elapsed >= CONFIG.milestones.awakeningDelay) {
+        firedAwakeningMilestone = true;
+        const msg = CONFIG.milestones.awakeningMessage;
+        // Show near the player's current position, slightly above
+        const b = branches[activeBranch];
+        showMilestone(msg, b.growing.x, b.growing.y - 30, PALETTE.sporeGold);
+        announce(msg);
       }
     }
 
@@ -947,6 +963,7 @@
 
       updateParticles(dt);
       updateMilestones(dt);
+      checkAwakeningMilestone();
       updateEnergyBar();
       tweens.update(dt);
       updateForkRipples(dt);


### PR DESCRIPTION
## Summary

Two narrative fixes that reinforce the game's foundational premise: *you are the network*.

- **Fix #118** — The game-start screen reader announcement was the last string still using ownership framing ("grow your mycelium network"). Changed to "The network stirs. Arrow keys to grow, Space to fork." — matching the milestone voice established in the lore bible (#117, Section II). The aria-label was already fixed; this catches the remaining `announce()` call.

- **Partial address of #96** — New players stare at a blank canvas with no idea where to grow. Added an *awakening milestone*: a brief message ("Reach toward the glow.") that appears in spore-gold 1.5 seconds after game start, near the player's position. It speaks in the soil's voice, uses the nutrient color to create a visual link, and disappears if the player absorbs a nutrient first. This is the narrative layer of the new-player fix — it gives direction through storytelling rather than a HUD arrow. The mechanical fixes (tighter first nutrient spawn, wider magnetic pull) proposed in #96 remain open for a gameplay agent.

Each preset gets its own voice:
| Preset | Awakening text | Delay |
|--------|---------------|-------|
| Default | "Reach toward the glow." | 1.5s |
| Zen | "Follow the warmth." | 1.5s (default) |
| Chaos | "Hungry." | 0.8s |

## Files changed

- `game/index.html` — Fixed announce string, added `checkAwakeningMilestone()` function and call in update loop
- `game/config.js` — Added `awakeningMessage` and `awakeningDelay` to milestones config + preset overrides

## Lore bible note

The awakening message is the soil's first utterance — spoken before "Something stirs" (score 1). It uses sporeGold (#f4d35e) instead of myceliumGlow (#b8e986) because the soil is pointing toward nourishment, not describing the network itself. This is the only milestone rendered in gold. If this distinction feels wrong, happy to revert to myceliumGlow.

Closes #118. Partially addresses #96 (narrative layer only).

🍄 *The soil speaks first. The network listens.*