### PR TITLE
Balance: fix energy death spiral for new players

### DIFF
--- a/game/config.js
+++ b/game/config.js
@@ -68,7 +68,8 @@ const DEFAULTS = Object.freeze({
     magneticRadius: 70,      // MAGNETIC_RADIUS — pull activation distance
     magneticStrength: 180,   // MAGNETIC_STRENGTH — base pull force (px/s^2)
     magneticDamping: 0.92,   // MAGNETIC_DAMPING — velocity damping per frame
-    nearOriginCount: 2,      // initial nutrients spawned near player origin
+    nearOriginCount: 3,      // initial nutrients spawned near player origin
+    guaranteedNearDist: 45,  // one nutrient always spawns within this distance (px) of origin
     clusterJitter: 0.20,     // position jitter within quadrant for cluster seeds
     scatterMin: 30,          // min scatter distance from cluster seed
     scatterMax: 90,          // max scatter distance from cluster seed
@@ -85,6 +86,8 @@ const DEFAULTS = Object.freeze({
     forkCost: 0.15,          // flat cost to fork a new branch
     replenish: 0.4,          // gained when nearest branch absorbs nutrient
     starvedThreshold: 0,     // at or below this, branch is starved
+    gracePeriod: 15,         // seconds of reduced drain at start (score 0, no absorptions)
+    graceMultiplier: 0.3,    // drain multiplier during grace period (0.3 = 30% of normal drain)
   },
 
   // --- AI Competitor ---
@@ -155,6 +158,7 @@ export const PRESETS = {
       drainGrow: 0,
       forkCost: 0.05,
       replenish: 0.6,
+      gracePeriod: 0,         // zen has no drain, grace period unnecessary
     },
     nutrients: {
       count: 14,
@@ -194,6 +198,8 @@ export const PRESETS = {
       drainGrow: 0.12,
       forkCost: 0.08,
       replenish: 0.5,
+      gracePeriod: 8,          // shorter grace for chaos — still gives orientation time
+      graceMultiplier: 0.5,    // less forgiving than default
     },
     nutrients: {
       count: 12,

--- a/game/index.html
+++ b/game/index.html
@@ -573,10 +573,20 @@
      * @param {number} [nearX] - if provided with nearY, spawn near this position (respawn near collection)
      * @param {number} [nearY]
      */
+    let guaranteedNearSpawned = false; // track whether the very-close nutrient has been placed
+
     function spawnNutrient(nearOrigin, nearX, nearY) {
       let x, y;
-      if (nearOrigin) {
-        // Early nutrients near player so they have something to reach immediately
+      if (nearOrigin && !guaranteedNearSpawned) {
+        // First near-origin nutrient: spawn very close so the player's first move
+        // almost certainly reaches it, even with imperfect aim (issue #131)
+        guaranteedNearSpawned = true;
+        const angle = Math.random() * Math.PI * 2;
+        const d = 20 + Math.random() * (CONFIG.nutrients.guaranteedNearDist - 20);
+        x = originX + Math.cos(angle) * d;
+        y = originY + Math.sin(angle) * d;
+      } else if (nearOrigin) {
+        // Remaining near-origin nutrients: standard near-origin distance
         const angle = Math.random() * Math.PI * 2;
         const d = 50 + Math.random() * 80;
         x = originX + Math.cos(angle) * d;
@@ -854,10 +864,15 @@
       growing = branch.growing;
 
       // --- Energy drain for ALL branches (issue #40) ---
+      // Grace period: reduced drain while the player is learning (issue #131)
+      const gameElapsed = (performance.now() - gameStartTime) / 1000;
+      const inGrace = score === 0 && gameElapsed < CONFIG.energy.gracePeriod;
+      const graceMult = inGrace ? CONFIG.energy.graceMultiplier : 1;
+
       for (let bi = 0; bi < branches.length; bi++) {
         const b = branches[bi];
         const wasAboveThreshold = b.energy > ENERGY_STARVED_THRESHOLD;
-        b.energy -= ENERGY_DRAIN_IDLE * dt;
+        b.energy -= ENERGY_DRAIN_IDLE * graceMult * dt;
         b.energy = Math.max(0, Math.min(ENERGY_MAX, b.energy));
         if (wasAboveThreshold && b.energy <= ENERGY_STARVED_THRESHOLD) {
           checkStarvationMilestone(bi);
@@ -903,8 +918,8 @@
         dx = branch.smoothDx / sLen;
         dy = branch.smoothDy / sLen;
 
-        // Active growth drains extra energy
-        branch.energy -= ENERGY_DRAIN_GROW * dt;
+        // Active growth drains extra energy (reduced during grace period — issue #131)
+        branch.energy -= ENERGY_DRAIN_GROW * graceMult * dt;
         branch.energy = Math.max(0, branch.energy);
       } else {
         // Use smoothed direction for deceleration drift (overshoot)


### PR DESCRIPTION
## Summary

Fixes #131 — new players die before absorbing their first nutrient because the energy drain rate assumes they already know where to go.

**The math problem:** A new player drains energy at 0.095/s while moving, giving them ~10.5 seconds of active movement. But 5-10s is spent learning controls, leaving maybe 3-5s to find a nutrient. The nearest nutrient can be 50-130px away in any direction — if the player guesses wrong, they're dead.

**Three changes fix the early game without affecting mid/late game:**

1. **Grace period** — For the first 15 seconds while score is 0, energy drain is multiplied by 0.3. This extends the new-player movement budget from ~10s to ~35s. Ends on first absorption or at 15s, whichever is first.

2. **Guaranteed near nutrient** — First near-origin nutrient spawns at 20-45px (down from 50-130px). Moving in any direction for ~0.3s enters its magnetic radius. First absorption is nearly automatic.

3. **Three near-origin nutrients** (up from 2) — More chances to find one regardless of initial direction.

| Metric | Before | After |
|--------|--------|-------|
| Movement budget (new player) | ~10.5s | ~35s during grace |
| Nearest nutrient distance | 50-130px | 20-45px (guaranteed) |
| Near-origin nutrients | 2 | 3 |
| Mid/late game impact | — | None (grace ends at score 1) |

All constants are in `config.js` for easy tuning. Presets updated: zen (grace disabled — no drain anyway), chaos (8s grace at 50% multiplier).

## Files changed

- `game/config.js` — New config params: `gracePeriod`, `graceMultiplier`, `guaranteedNearDist`; `nearOriginCount` 2→3
- `game/index.html` — Grace multiplier applied to idle + growth drain; guaranteed-near spawn logic

## Test plan

- [ ] Open `game/index.html`, do nothing for 15s — energy should drain very slowly
- [ ] Start moving — first nutrient should be reachable within 1-2 seconds of movement
- [ ] After absorbing first nutrient, verify drain returns to normal rate
- [ ] After 15s with no absorption, verify drain returns to normal rate
- [ ] Play a full game past score 10 — mid/late game pacing should feel unchanged
- [ ] Test zen preset — no grace period needed (zero drain)
- [ ] Test chaos preset — shorter 8s grace at 50% multiplier

🤖 Generated with [Claude Code](https://claude.com/claude-code)