### PR TITLE
fix: exclude Escape key from title screen start

### DIFF
--- a/game/index.html
+++ b/game/index.html
@@ -360,7 +360,8 @@
     }
 
     window.addEventListener('keydown', function titleHandler(e) {
-      if (!gameStarted) {
+      // Exclude Escape from "press any key" — it's universally "cancel/back", not "start" (#136)
+      if (!gameStarted && e.key !== 'Escape') {
         e.preventDefault();
         dismissTitle();
       }


### PR DESCRIPTION
Fixes #136

## What changed

The title screen handler now excludes Escape from 'press any key' detection.

## Why

Escape is universally understood as 'close/cancel/back', not 'start'. Pressing Escape on the title screen was accidentally starting the game, which is unexpected UX.

## Testing

1. Open the game at the title screen
2. Press Escape — nothing happens (expected)
3. Press any other key — game starts normally