### PR TITLE
fix: cap timelapse snapshots with ring buffer (memory leak)

### DIFF
--- a/game/config.js
+++ b/game/config.js
@@ -130,6 +130,7 @@ const DEFAULTS = Object.freeze({
     particleBurstCount: 14,  // particles per burst
     snapshotInterval: 6,     // capture every N frames for timelapse
     replaySpeed: 10,         // snapshots advanced per frame during replay
+    maxSnapshots: 200,       // ring buffer cap for timelapse (prevents memory leak #106)
     // Segment ripple — secondary motion (issue #83)
     rippleStiffness: 120,    // spring stiffness — higher = faster oscillation
     rippleDamping: 8,        // spring damping — higher = settles quicker

--- a/game/index.html
+++ b/game/index.html
@@ -1415,16 +1415,25 @@
       renderMilestones();
     }
 
-    // --- Timelapse Replay (issue #41) ---
+    // --- Timelapse Replay (issue #41, #106) ---
     const replaySnapshots = [];
     let frameCount = 0;
+    let snapshotWriteIndex = 0; // ring buffer write position (#106)
     const SNAPSHOT_INTERVAL = CONFIG.fx.snapshotInterval; // capture interval (issue #119)
     let replayMode = false;
     let replayIndex = 0;
     let replayDone = false;
 
     function captureSnapshot() {
-      replaySnapshots.push(canvas.toDataURL('image/png'));
+      // Ring buffer to prevent memory leak (#106)
+      // Cap at maxSnapshots — old frames get overwritten
+      const maxSnapshots = CONFIG.fx.maxSnapshots;
+      if (replaySnapshots.length < maxSnapshots) {
+        replaySnapshots.push(canvas.toDataURL('image/png'));
+      } else {
+        replaySnapshots[snapshotWriteIndex % maxSnapshots] = canvas.toDataURL('image/png');
+      }
+      snapshotWriteIndex++;
     }
 
     function startReplay() {
@@ -1432,6 +1441,20 @@
       replayMode = true;
       replayIndex = 0;
       replayDone = false;
+    }
+
+    // Get the actual snapshot at logical index, accounting for ring buffer (#106)
+    function getReplaySnapshot(logicalIndex) {
+      const maxSnapshots = CONFIG.fx.maxSnapshots;
+      const len = replaySnapshots.length;
+      if (len < maxSnapshots) {
+        // Buffer not full yet — straightforward linear access
+        return replaySnapshots[logicalIndex];
+      }
+      // Buffer is full — oldest frame is at snapshotWriteIndex % maxSnapshots
+      const startIndex = snapshotWriteIndex % maxSnapshots;
+      const actualIndex = (startIndex + logicalIndex) % len;
+      return replaySnapshots[actualIndex];
     }
 
     function renderReplayFrame() {
@@ -1463,7 +1486,7 @@
         ctx.fillText('REPLAY', W - 20, 30);
         ctx.restore();
       };
-      img.src = replaySnapshots[replayIndex];
+      img.src = getReplaySnapshot(Math.floor(replayIndex));
 
       // Replay speed configurable via CONFIG (issue #119)
       replayIndex += CONFIG.fx.replaySpeed;


### PR DESCRIPTION
Fixes #106

## Problem

The timelapse replay stored unbounded PNG snapshots in RAM:
- 10 snapshots/second × 300KB each = 3MB/second
- 5-minute session = ~900MB of base64 strings in memory
- Causes stuttering, eventual tab crash

## Solution

Ring buffer with configurable cap (default 200 snapshots = ~20 seconds of replay):

1. Added `CONFIG.fx.maxSnapshots` (200) to config.js
2. Modified `captureSnapshot()` to overwrite old frames when buffer is full
3. Updated replay playback to read frames in correct chronological order (oldest → newest)

## Memory impact

- Before: O(n) where n = session duration
- After: O(1) capped at ~60-80MB

## Testing

1. Play for 5+ minutes
2. Press Escape to trigger replay
3. Replay shows last ~20 seconds (most recent 200 frames)
4. Memory usage stays stable (check DevTools → Memory)