### PR TITLE
UI: HUD visual hierarchy, readability, and responsive scaling

### DIFF
--- a/game/index.html
+++ b/game/index.html
@@ -33,44 +33,59 @@
       position: absolute;
       top: 16px;
       left: 20px;
-      font-size: 16px;
+      font-size: clamp(18px, 2.5vw, 24px);
       color: #b8e986;
       text-shadow: 0 0 10px rgba(184, 233, 134, 0.5);
       z-index: 10;
       pointer-events: none;
+      letter-spacing: 1px;
     }
     #branch-hint {
       position: absolute;
-      top: 40px;
+      top: 46px;
       left: 20px;
-      font-size: 13px;
-      color: rgba(184, 233, 134, 0.75);
+      font-size: clamp(11px, 1.4vw, 13px);
+      color: rgba(184, 233, 134, 0.55);
       z-index: 10;
       pointer-events: none;
     }
     #energy-bar {
       position: absolute;
-      top: 62px;
+      top: 68px;
       left: 20px;
-      font-size: 12px;
-      color: rgba(184, 233, 134, 0.8);
+      font-size: clamp(10px, 1.3vw, 12px);
+      color: rgba(184, 233, 134, 0.7);
       z-index: 10;
       pointer-events: none;
+      display: flex;
+      align-items: center;
+      gap: 8px;
     }
     #energy-bar .bar-bg {
       display: inline-block;
-      width: 120px;
-      height: 8px;
+      width: clamp(100px, 15vw, 160px);
+      height: 10px;
       background: rgba(255,255,255,0.08);
-      border-radius: 4px;
+      border-radius: 5px;
       vertical-align: middle;
-      margin-left: 6px;
       overflow: hidden;
     }
     #energy-bar .bar-fill {
       height: 100%;
-      border-radius: 4px;
+      border-radius: 5px;
       transition: width 0.15s ease, background 0.3s ease;
+    }
+    #rival-score {
+      position: absolute;
+      top: 16px;
+      right: 20px;
+      font-size: clamp(12px, 1.6vw, 14px);
+      color: #c47335;
+      text-shadow: 0 0 10px rgba(196, 115, 53, 0.5);
+      z-index: 10;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.8s ease;
     }
     .controls {
       position: absolute;
@@ -78,11 +93,13 @@
       left: 0;
       right: 0;
       text-align: center;
-      font-size: 12px;
-      color: rgba(184, 233, 134, 0.7);
+      font-size: clamp(10px, 1.3vw, 12px);
+      color: rgba(184, 233, 134, 0.5);
       z-index: 10;
       pointer-events: none;
+      transition: opacity 2s ease;
     }
+    .controls.faded { opacity: 0; }
     /* --- Title Screen Overlay --- */
     #title-screen {
       position: absolute;
@@ -102,21 +119,21 @@
     }
     #title-screen h1 {
       font-family: monospace;
-      font-size: 56px;
-      letter-spacing: 18px;
+      font-size: clamp(32px, 7vw, 56px);
+      letter-spacing: clamp(8px, 2vw, 18px);
       color: #b8e986;
       text-shadow: 0 0 30px rgba(184, 233, 134, 0.6), 0 0 60px rgba(184, 233, 134, 0.2);
       margin-bottom: 16px;
       text-transform: uppercase;
     }
     #title-screen .tagline {
-      font-size: 15px;
+      font-size: clamp(12px, 1.8vw, 15px);
       color: rgba(184, 233, 134, 0.75);
-      letter-spacing: 4px;
+      letter-spacing: clamp(2px, 0.5vw, 4px);
       margin-bottom: 48px;
     }
     #title-screen .prompt {
-      font-size: 13px;
+      font-size: clamp(11px, 1.5vw, 13px);
       color: rgba(184, 233, 134, 0.4);
       letter-spacing: 3px;
       animation: pulse-prompt 2s ease-in-out infinite;
@@ -142,7 +159,7 @@
     }
     #pause-overlay.visible { display: flex; }
     #pause-overlay span {
-      font-size: 32px;
+      font-size: clamp(22px, 4vw, 32px);
       color: #b8e986;
       letter-spacing: 8px;
       text-shadow: 0 0 20px rgba(184, 233, 134, 0.5);
@@ -170,38 +187,55 @@
     #game-over-overlay.visible { display: flex; }
     #game-over-overlay h2 {
       font-family: monospace;
-      font-size: 28px;
+      font-size: clamp(22px, 3.5vw, 32px);
       color: #7b2d8e;
       text-shadow: 0 0 20px rgba(123, 45, 142, 0.5);
       letter-spacing: 6px;
-      margin-bottom: 12px;
+      margin-bottom: 20px;
     }
     #game-over-overlay .stats {
-      font-size: 14px;
+      font-size: clamp(13px, 1.8vw, 16px);
       color: rgba(184, 233, 134, 0.8);
+      margin-bottom: 4px;
+      text-align: center;
+      line-height: 1.8;
+    }
+    #game-over-overlay .stat-highlight {
+      color: #f4d35e;
+      font-size: clamp(20px, 2.8vw, 28px);
+      text-shadow: 0 0 12px rgba(244, 211, 94, 0.4);
+      display: block;
       margin-bottom: 8px;
     }
     #game-over-overlay .restart-hint {
-      font-size: 13px;
-      color: rgba(184, 233, 134, 0.5);
+      font-size: clamp(11px, 1.4vw, 13px);
+      color: rgba(184, 233, 134, 0.4);
       letter-spacing: 3px;
-      margin-top: 16px;
+      margin-top: 24px;
+      animation: pulse-prompt 2s ease-in-out infinite;
     }
     #fork-feedback {
       position: absolute;
-      z-index: 10;
-      font-size: 11px;
+      z-index: 20;
+      font-size: clamp(12px, 1.5vw, 14px);
       font-family: monospace;
-      color: rgba(123, 45, 142, 0.9);
-      text-shadow: 0 0 6px rgba(123, 45, 142, 0.4);
+      color: #f4d35e;
+      text-shadow: 0 0 8px rgba(244, 211, 94, 0.6), 0 0 2px rgba(0, 0, 0, 0.8);
       pointer-events: none;
       opacity: 0;
-      transition: opacity 0.15s ease;
+      transition: opacity 0.2s ease;
+      letter-spacing: 1px;
+      background: rgba(10, 14, 15, 0.6);
+      padding: 4px 10px;
+      border-radius: 4px;
+      border-left: 2px solid rgba(244, 211, 94, 0.4);
     }
     #fork-feedback.visible { opacity: 1; }
     @media (prefers-reduced-motion: reduce) {
       #fork-feedback { transition: none; }
       #game-over-overlay { transition: none; }
+      .controls { transition: none; }
+      #game-over-overlay .restart-hint { animation: none; opacity: 0.8; }
     }
   </style>
 </head>
@@ -213,8 +247,8 @@
       <div class="prompt">press any key</div>
     </div>
     <div id="score">Absorbed: 0</div>
-    <div id="rival-score" style="position:absolute;top:16px;right:20px;font-size:14px;color:#c47335;text-shadow:0 0 10px rgba(196,115,53,0.5);z-index:10;pointer-events:none;opacity:0;transition:opacity 0.8s ease;"></div>
-    <div id="branch-hint">Tendril 1/1 &nbsp;[Space to fork, Tab to switch]</div>
+    <div id="rival-score"></div>
+    <div id="branch-hint">Tendril 1/1</div>
     <div id="energy-bar">Energy <span class="bar-bg"><span class="bar-fill" id="energy-fill"></span></span></div>
     <canvas id="game" width="960" height="640" tabindex="0" role="img" aria-label="Mycelium game canvas. Use arrow keys or WASD to grow, Space to fork, Tab to switch tendrils, P to pause, M to mute, Escape for replay."><p>Mycelium: a fungal network growth game. Requires a browser with canvas and keyboard support.</p></canvas>
     <div id="pause-overlay"><span>PAUSED</span></div>
@@ -318,6 +352,11 @@
       // Initialize procedural audio on user gesture (browser autoplay policy)
       if (!muted) initAudio();
       announce('The network stirs. Arrow keys to grow, Space to fork.');
+      // Fade out controls hint after 8 seconds — player should know the keys by then
+      const controlsEl = document.querySelector('.controls');
+      if (controlsEl) {
+        setTimeout(() => { controlsEl.classList.add('faded'); }, 8000);
+      }
     }
 
     window.addEventListener('keydown', function titleHandler(e) {
@@ -793,7 +832,7 @@
     }
 
     function updateBranchHint() {
-      branchHintEl.textContent = 'Tendril ' + (activeBranch + 1) + '/' + branches.length + '  [Space to fork, Tab to switch]';
+      branchHintEl.textContent = 'Tendril ' + (activeBranch + 1) + '/' + branches.length;
     }
 
     // --- Input ---
@@ -848,7 +887,7 @@
         if (!muted) triggerGameOver();
         const elapsed = ((performance.now() - gameStartTime) / 1000).toFixed(0);
         const statsText = 'Absorbed: ' + score + '  |  Tendrils: ' + branches.length + '  |  ' + elapsed + 's survived';
-        gameOverStats.textContent = statsText;
+        gameOverStats.innerHTML = '<span class="stat-highlight">' + score + ' absorbed</span>' + branches.length + ' tendrils &middot; ' + elapsed + 's survived';
         gameOverOverlay.classList.add('visible');
         announce('All tendrils have withered. ' + statsText + '. Press R to restart.');
       }


### PR DESCRIPTION
## What changed

Reworks the HUD to establish clear information hierarchy — the most important thing the player needs to know at any moment should be the most visible thing on screen.

### Visual hierarchy (what matters most reads first)

- **Score** — largest HUD element now (18-24px via clamp), with letter-spacing for legibility. This is the player's primary progress indicator.
- **Energy bar** — wider (100-160px responsive) and taller (10px up from 8px). Energy is the most urgent gameplay signal — it determines life or death — so it needs to be readable at a glance without squinting.
- **Branch hint** — condensed to just "Tendril N/N". The "[Space to fork, Tab to switch]" instructions are redundant with the controls bar at the bottom. Less text = less competition for the player's attention.
- **Controls bar** — starts visible, fades out after 8 seconds of gameplay. New players see the controls, experienced players get a cleaner screen.

### Fork feedback visibility (addresses #130)

The old fork feedback used decay violet at 11px — nearly invisible against the dark background during active gameplay. Now uses:
- Gold (#f4d35e) text with dark background pill
- Left border accent for quick visual parsing
- Higher z-index (20 vs 10) so it sits above other HUD elements
- Larger text (12-14px responsive)

### Game-over screen

- Score displayed large and gold as the hero stat — it's what the player cares about most
- Tendrils and survival time on a secondary line with a middle dot separator
- Restart hint pulses (reuses the title screen animation) to draw the eye
- Better spacing between elements

### Responsive scaling

All text elements now use `clamp()` for font sizes, so they scale gracefully from small windows to full desktop. Title screen, pause overlay, and game-over overlay all scale too. No more fixed pixel sizes that become unreadable at 720p or smaller viewports.

### Cleanup

- Rival score: moved from inline `style=""` attribute to a proper CSS rule — consistent with every other HUD element
- Added `prefers-reduced-motion` support for the new controls fade transition and game-over restart animation

## What the player experiences

- Cleaner screen during gameplay — less visual noise competing with the game world
- Score and energy are immediately readable without searching
- Fork failure feedback is now actually visible (gold on dark pill vs invisible violet)
- Game-over screen gives you your score as a clear headline, not buried in a pipe-delimited string
- Everything stays readable on smaller screens

Fixes #130