### PR TITLE
VFX: damped-spring segment ripple on growth and fork (fixes #83)

### DIFF
--- a/game/config.js
+++ b/game/config.js
@@ -130,6 +130,13 @@ const DEFAULTS = Object.freeze({
     particleBurstCount: 14,  // particles per burst
     snapshotInterval: 6,     // capture every N frames for timelapse
     replaySpeed: 10,         // snapshots advanced per frame during replay
+    // Segment ripple — secondary motion (issue #83)
+    rippleStiffness: 120,    // spring stiffness — higher = faster oscillation
+    rippleDamping: 8,        // spring damping — higher = settles quicker
+    rippleImpulse: 18,       // wobble velocity injected per new segment
+    rippleForkImpulse: 35,   // stronger impulse on fork events
+    rippleDepth: 4,          // how many segments back the ripple reaches
+    rippleDecay: 0.3,        // amplitude falloff per segment (multiplied)
   },
 
   // --- Audio ---

--- a/game/index.html
+++ b/game/index.html
@@ -705,6 +705,61 @@
       }
     }
 
+    // --- Segment ripple — secondary motion (issue #83) ---
+    // When a tip advances far enough to commit a new segment, a wobble impulse
+    // propagates backward through the 3-4 nearest segments on the same branch.
+    // Each segment's wobble oscillates via a damped spring and settles back to
+    // its rest position within ~300ms. Forks inject a stronger impulse.
+    // Purely visual — no gameplay impact.
+
+    /**
+     * Inject a ripple impulse into segments near a branch tip.
+     * @param {number} branchIndex — the branch that just grew or forked
+     * @param {number} impulse — initial wobbleVelocity magnitude
+     */
+    function injectSegmentRipple(branchIndex, impulse) {
+      if (prefersReducedMotion) return;
+      const depth = CONFIG.fx.rippleDepth;
+      const decay = CONFIG.fx.rippleDecay;
+      // Walk backward through segments belonging to this branch, newest first
+      let count = 0;
+      for (let i = network.segments.length - 1; i >= 0 && count < depth; i--) {
+        const seg = network.segments[i];
+        if (seg.branch !== branchIndex) continue;
+        // Initialize spring properties if missing
+        if (seg.restWobble === undefined) {
+          seg.restWobble = seg.wobble;
+          seg.wobbleVelocity = 0;
+        }
+        // Impulse decays with distance from the tip
+        const factor = Math.pow(1 - decay, count);
+        seg.wobbleVelocity += impulse * factor * (Math.random() > 0.5 ? 1 : -1);
+        count++;
+      }
+    }
+
+    /**
+     * Update damped-spring wobble on all segments that have active velocity.
+     * Called once per frame from the game loop.
+     * Spring equation: a = -stiffness * displacement - damping * velocity
+     */
+    function updateSegmentRipples(dt) {
+      const stiffness = CONFIG.fx.rippleStiffness;
+      const damping = CONFIG.fx.rippleDamping;
+      for (const seg of network.segments) {
+        if (seg.wobbleVelocity === undefined || seg.wobbleVelocity === 0) continue;
+        const displacement = seg.wobble - seg.restWobble;
+        const accel = -stiffness * displacement - damping * seg.wobbleVelocity;
+        seg.wobbleVelocity += accel * dt;
+        seg.wobble += seg.wobbleVelocity * dt;
+        // Kill tiny oscillations to avoid infinite micro-updates
+        if (Math.abs(seg.wobbleVelocity) < 0.5 && Math.abs(displacement) < 0.2) {
+          seg.wobble = seg.restWobble;
+          seg.wobbleVelocity = 0;
+        }
+      }
+    }
+
     // --- Nutrient absorption animation (squash-and-pop) ---
     const absorptionAnims = []; // {x, y, age, duration, color}
 
@@ -805,10 +860,13 @@
         const newNode = { x: current.growing.x, y: current.growing.y, radius: NODE_RADIUS };
         network.nodes.push(newNode);
         const newIndex = network.nodes.length - 1;
-        network.segments.push({ from: current.tipIndex, to: newIndex, wobble: genWobble(current.growing.dist), branch: activeBranch });
+        const forkSegWobble = genWobble(current.growing.dist);
+        network.segments.push({ from: current.tipIndex, to: newIndex, wobble: forkSegWobble, restWobble: forkSegWobble, wobbleVelocity: 0, branch: activeBranch });
         current.tipIndex = newIndex;
         current.growing.dist = 0;
       }
+      // Fork ripple: stronger impulse propagates backward through parent branch (#83)
+      injectSegmentRipple(activeBranch, CONFIG.fx.rippleForkImpulse);
       const forkTip = current.tipIndex;
       const forkNode = network.nodes[forkTip];
       const childEnergy = current.energy * 0.5;
@@ -1007,7 +1065,10 @@
           const newNode = { x: growing.x, y: growing.y, radius: NODE_RADIUS };
           network.nodes.push(newNode);
           const newIndex = network.nodes.length - 1;
-          network.segments.push({ from: tipIndex, to: newIndex, wobble: genWobble(growing.dist), branch: activeBranch });
+          const segWobble = genWobble(growing.dist);
+          network.segments.push({ from: tipIndex, to: newIndex, wobble: segWobble, restWobble: segWobble, wobbleVelocity: 0, branch: activeBranch });
+          // Ripple: new segment sends a wobble impulse backward (#83)
+          injectSegmentRipple(activeBranch, CONFIG.fx.rippleImpulse);
           tipIndex = newIndex;
           branch.tipIndex = newIndex;
           branch.wobble = genWobble(growing.dist);
@@ -1021,6 +1082,7 @@
       updateEnergyBar();
       tweens.update(dt);
       updateForkRipples(dt);
+      updateSegmentRipples(dt); // issue #83: secondary motion on segments
       updateAbsorptionAnims(dt);
 
       // --- Magnetic nutrient pull — active branch only (issue #90) ---


### PR DESCRIPTION
Fixes #83

## What the player sees

When a tendril tip advances far enough to commit a new node, the 3-4 segments behind it briefly wobble — a quick oscillation of the bezier control point that decays within ~300ms. The effect is subtle but transforms the network from a static painting into a connected living system. Forking triggers a stronger ripple through the parent branch, so the split feels physical — like a vine snapping under tension.

## How it works

Each segment already has a `wobble` property that offsets the bezier control point. This PR adds two companion fields:

- **`restWobble`** — the resting position (set once at creation, never changes)
- **`wobbleVelocity`** — the current oscillation speed (starts at 0)

When a new segment is committed or a fork happens, `injectSegmentRipple()` walks backward through the branch's segments and kicks their velocity. The impulse decays with distance from the tip (configurable via `rippleDecay`).

Every frame, `updateSegmentRipples()` runs a damped spring on each active segment:

```
acceleration = -stiffness * (wobble - restWobble) - damping * wobbleVelocity
```

The rendering pipeline already reads `seg.wobble` for the bezier control point offset — zero changes needed to the draw code. The oscillation is visible through the existing quadratic curves.

## Configuration

All values are tunable via `CONFIG.fx`:

| Parameter | Default | Purpose |
|-----------|---------|---------|
| `rippleStiffness` | 120 | Spring stiffness — higher = faster oscillation |
| `rippleDamping` | 8 | Spring damping — higher = settles quicker |
| `rippleImpulse` | 18 | Velocity injected on normal segment creation |
| `rippleForkImpulse` | 35 | Stronger impulse on fork events |
| `rippleDepth` | 4 | How many segments back the ripple reaches |
| `rippleDecay` | 0.3 | Amplitude falloff per segment step |

Runtime tweaking via `Mycelium.config.fx.rippleStiffness = 200` works as expected.

## Performance

- No new allocations per frame — the spring runs inline on existing segment objects
- Tiny oscillations (velocity < 0.5, displacement < 0.2) snap to rest immediately
- Maximum 4 segments per branch are ever active, and only briefly
- `prefers-reduced-motion` suppresses all ripple injection

## Files changed

- `game/config.js` — added 6 `ripple*` config values under `fx`
- `game/index.html` — added `injectSegmentRipple()`, `updateSegmentRipples()`, wired into segment creation, fork, and game loop