### PR TITLE
fix: skip snapshot capture while paused or game over

### DIFF
--- a/game/index.html
+++ b/game/index.html
@@ -1542,7 +1542,8 @@
         render(now);
 
         // Capture snapshot every SNAPSHOT_INTERVAL frames
-        if (gameStarted) {
+        // Skip while paused or after game over to avoid wasting memory on identical frames (#135)
+        if (gameStarted && !paused && !gameOver) {
           frameCount++;
           if (frameCount % SNAPSHOT_INTERVAL === 0) {
             captureSnapshot();


### PR DESCRIPTION
Fixes #135

## Problem

Snapshots were being captured even when the game was paused (P key) or after game over, producing identical frames that waste memory.

A player who pauses for 60 seconds accumulates ~600 redundant snapshots (~48MB).

## Solution

Added `!paused && !gameOver` to the capture condition:

```js
if (gameStarted && !paused && !gameOver) {
  // capture snapshots
}
```

## Testing

1. Start game, press P to pause
2. Wait 30 seconds
3. Resume — memory usage should not have increased while paused