### PR TITLE
fix: track active play time instead of wall clock (pause exploit)

### DIFF
--- a/game/index.html
+++ b/game/index.html
@@ -852,8 +852,9 @@
       if (allStarved) {
         gameOver = true;
         if (!muted) triggerGameOver();
-        const elapsed = ((performance.now() - gameStartTime) / 1000).toFixed(0);
-        const statsText = 'Absorbed: ' + score + '  |  Tendrils: ' + branches.length + '  |  ' + elapsed + 's survived';
+        // Use active play time (excludes paused time) for accurate timing (#144)
+        const playTime = activePlayTime.toFixed(0);
+        const statsText = 'Absorbed: ' + score + '  |  Tendrils: ' + branches.length + '  |  ' + playTime + 's played';
         gameOverStats.textContent = statsText;
         gameOverOverlay.classList.add('visible');
         announce('All tendrils have withered. ' + statsText + '. Press R to restart.');
@@ -861,6 +862,8 @@
     }
 
     let gameStartTime = 0;
+    let activePlayTime = 0; // Track actual play time (excludes paused time) #144
+    let lastFrameTime = 0;  // For calculating dt when tracking active time
 
     function update(dt) {
       if (!gameStarted || paused || gameOver) return;
@@ -1545,6 +1548,7 @@
         // Skip while paused or after game over to avoid wasting memory on identical frames (#135)
         if (gameStarted && !paused && !gameOver) {
           frameCount++;
+          activePlayTime += dt; // Track actual play time (#144)
           if (frameCount % SNAPSHOT_INTERVAL === 0) {
             captureSnapshot();
           }


### PR DESCRIPTION
Fixes #144

## Problem

Pausing doesn't stop the clock — a player who pauses 50 times shows the same 'survived Xs' as someone who played continuously, but had unlimited thinking time.

## Solution

Track actual active play time:
- Added `activePlayTime` variable
- Accumulate `dt` only when `gameStarted && !paused && !gameOver`
- Game-over screen shows 'Xs played' (active time) not 'Xs survived' (wall time)

## Testing

1. Start a game
2. Pause for 30 seconds (P key)
3. Continue playing for 10 seconds, then die
4. Game-over shows '10s played' not '40s survived'