### PR TITLE
fix: give nutrient energy to collecting branch, not nearest

### DIFF
--- a/game/index.html
+++ b/game/index.html
@@ -1033,16 +1033,19 @@
         n.y = Math.max(10, Math.min(H - 10, n.y));
       }
 
-      // Collection
+      // Collection — energy goes to the collecting branch, not nearest (#141)
       for (let i = nutrients.length - 1; i >= 0; i--) {
         const n = nutrients[i];
+        // Check active branch first
         if (dist(growing.x, growing.y, n.x, n.y) < COLLECT_RADIUS) {
-          collectNutrient(i, n.x, n.y); continue;
+          collectNutrient(i, n.x, n.y, activeBranch); continue;
         }
+        // Check all other branches
         let collected = false;
-        for (const b of branches) {
+        for (let bi = 0; bi < branches.length; bi++) {
+          const b = branches[bi];
           if (dist(b.growing.x, b.growing.y, n.x, n.y) < COLLECT_RADIUS) {
-            collectNutrient(i, n.x, n.y); collected = true; break;
+            collectNutrient(i, n.x, n.y, bi); collected = true; break;
           }
         }
         if (collected) continue;
@@ -1068,7 +1071,7 @@
       checkGameOver();
     }
 
-    function collectNutrient(index, nx, ny) {
+    function collectNutrient(index, nx, ny, collectingBranch) {
       const collected = nutrients[index];
       if (!prefersReducedMotion) {
         spawnBurst(collected.x, collected.y, PALETTE.sporeGold);
@@ -1081,9 +1084,10 @@
       if (!muted) triggerCollect();
       checkScoreMilestone();
 
-      // Replenish energy of nearest branch (issue #40)
-      const nearest = nearestBranch(nx, ny);
-      branches[nearest].energy = Math.min(ENERGY_MAX, branches[nearest].energy + ENERGY_REPLENISH);
+      // Replenish energy of the collecting branch (issue #141)
+      // Previously used nearestBranch which allowed farming exploits
+      const target = collectingBranch !== undefined ? collectingBranch : nearestBranch(nx, ny);
+      branches[target].energy = Math.min(ENERGY_MAX, branches[target].energy + ENERGY_REPLENISH);
 
       // Respawn near the same cluster region (issue #80)
       spawnNutrient(false, nx, ny);


### PR DESCRIPTION
Fixes #141

## Problem

Energy replenishment went to `nearestBranch()` instead of the branch that actually collected the nutrient. This allowed farming exploits:

1. Park a branch near nutrient clusters
2. Nutrients collected by parked branch give energy to it
3. Meanwhile, active branch can grow far away
4. Energy 'stolen' across the map

## Solution

Pass the collecting branch index to `collectNutrient()`:

```js
// Before
collectNutrient(i, n.x, n.y);  // energy → nearest

// After
collectNutrient(i, n.x, n.y, bi);  // energy → collector
```

## Testing

1. Fork a branch (Space)
2. Move active branch far from nutrients
3. Let the parked branch passively collect a nearby nutrient
4. Energy goes to the parked branch (correct), not your active branch