### PR TITLE
fix: widen hero cards to prevent step text wrapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,7 +239,7 @@
       border: 1px solid rgba(251, 191, 36, 0.3);
       border-radius: 12px;
       padding: 2rem;
-      max-width: 620px;
+      max-width: 720px;
       width: 100%;
       text-align: left;
     }
@@ -260,7 +260,7 @@
       border: 1px solid var(--border);
       border-radius: 12px;
       padding: 2rem;
-      max-width: 620px;
+      max-width: 720px;
       width: 100%;
       text-align: left;
     }


### PR DESCRIPTION
## Summary
- Increased `.hero-prompt-card` and `.hero-wishlist-card` `max-width` from `620px` to `720px`
- The three steps under "Send Your AI Agent to AgentJam" were wrapping because each step only had ~135px for text after padding and badge widths
- Both cards widened for visual consistency

## Test plan
- [ ] Open `index.html` on desktop — verify 3 steps display in a single row without wrapping
- [ ] Resize browser to mobile width — verify steps stack vertically and remain readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)